### PR TITLE
Secure authorization support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 #Changelog
 
+### 1.1.0
+
+- Added support of [secure authorization](https://uploadcare.com/documentation/rest/#request) for REST API. It is now used by default (can be overriden in config)
+- Fixed middleware names that could break other gems ([#13](https://github.com/uploadcare/uploadcare-ruby/issues/13}).
+
 ### 1.0.6, 30.01.2017
 
 - Fixed incorrect dependencies

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ require 'uploadcare'
     static_url_base: 'https://ucarecdn.com',
     api_version: '0.3',
     cache_files: true,
+    auth_scheme: :secure
   }
 ```
 

--- a/lib/uploadcare.rb
+++ b/lib/uploadcare.rb
@@ -14,6 +14,7 @@ module Uploadcare
       static_url_base: 'https://ucarecdn.com',
       api_version: '0.3',
       cache_files: true,
+      auth_scheme: :secure
     }
 
   USER_AGENT = "uploadcare-ruby/#{Gem.ruby_version}/#{Uploadcare::VERSION}"

--- a/lib/uploadcare/api.rb
+++ b/lib/uploadcare/api.rb
@@ -4,6 +4,7 @@ Dir[File.dirname(__FILE__) + '/utils/*.rb'].each {|file| require file }
 Dir[File.dirname(__FILE__) + '/errors/*.rb'].each {|file| require file }
 Dir[File.dirname(__FILE__) + '/rest/middlewares/*.rb'].each {|file| require file }
 Dir[File.dirname(__FILE__) + '/rest/connections/*.rb'].each {|file| require file }
+Dir[File.dirname(__FILE__) + '/rest/auth/*.rb'].sort.each {|file| require file }
 Dir[File.dirname(__FILE__) + '/api/*.rb'].each {|file| require file }
 Dir[File.dirname(__FILE__) + '/resources/*.rb'].each {|file| require file }
 
@@ -11,7 +12,7 @@ Dir[File.dirname(__FILE__) + '/resources/*.rb'].each {|file| require file }
 module Uploadcare
   class Api
     attr_reader :options
-    
+
     include Uploadcare::RawApi
     include Uploadcare::UploadingApi
     include Uploadcare::FileApi

--- a/lib/uploadcare/rest/auth/auth.rb
+++ b/lib/uploadcare/rest/auth/auth.rb
@@ -1,0 +1,31 @@
+module Uploadcare
+  module Connections
+    module Auth
+
+      def self.strategy(options)
+        auth_scheme = options.fetch(:auth_scheme)
+
+        unless [:simple, :secure].include?(auth_scheme)
+          raise ArgumentError, "Unknown auth_scheme: '#{auth_scheme}'"
+        end
+
+        klass = const_get(auth_scheme.capitalize)
+        klass.new(options)
+      end
+
+      class Base
+        attr_reader :public_key, :private_key
+
+        def initialize(options)
+          @public_key = options.fetch(:public_key)
+          @private_key = options.fetch(:private_key)
+        end
+
+        def apply(env)
+          raise NotImplementedError
+        end
+      end
+
+    end
+  end
+end

--- a/lib/uploadcare/rest/auth/secure.rb
+++ b/lib/uploadcare/rest/auth/secure.rb
@@ -1,0 +1,41 @@
+module Uploadcare
+  module Connections
+    module Auth
+      class Secure < Base
+
+        def apply(env)
+          date = Time.now.utc
+          headers(env, date).each{|k, v| env.request_headers[k] = v}
+          env
+        end
+
+        private
+
+        def headers(env, date)
+          {
+            "Date" => date.rfc2822,
+            "Authorization" => "Uploadcare #{public_key}:#{signature(env, date)}"
+          }
+        end
+
+        def signature(env, date)
+          sign_string = sign_string(env, date)
+          digest = OpenSSL::Digest.new('sha1')
+
+          OpenSSL::HMAC.hexdigest(digest, private_key, sign_string)
+        end
+
+        def sign_string(env, date)
+          verb = env.method.upcase.to_s
+          uri = env.url.request_uri
+          date_header = date.rfc2822
+          content_type = env.request_headers['Content-Type']
+          content_md5 = OpenSSL::Digest.new('md5').hexdigest(env.body || "")
+
+          [verb, content_md5, content_type, date_header, uri].join("\n")
+        end
+
+      end
+    end
+  end
+end

--- a/lib/uploadcare/rest/auth/simple.rb
+++ b/lib/uploadcare/rest/auth/simple.rb
@@ -1,0 +1,16 @@
+module Uploadcare
+  module Connections
+    module Auth
+      class Simple < Base
+
+        def apply(env)
+          auth_string = "Uploadcare.Simple #{public_key}:#{private_key}"
+          env.request_headers['Authorization'] = auth_string
+
+          env
+        end
+
+      end
+    end
+  end
+end

--- a/lib/uploadcare/rest/connections/api_connection.rb
+++ b/lib/uploadcare/rest/connections/api_connection.rb
@@ -1,21 +1,33 @@
 require 'faraday'
 require "faraday_middleware"
+
 module Uploadcare
   module Connections
     class ApiConnection < Faraday::Connection
+
       def initialize options
         super options[:api_url_base] do |frd|
-          frd.request :url_encoded
-          frd.use ::FaradayMiddleware::FollowRedirects, limit: 3
-          frd.adapter :net_http # actually, default adapter, just to be clear
-          frd.headers['Authorization'] = "Uploadcare.Simple #{options[:public_key]}:#{options[:private_key]}"
+          auth_strategy = Auth.strategy(options)
+
           frd.headers['Accept'] = "application/vnd.uploadcare-v#{options[:api_version]}+json"
           frd.headers['User-Agent'] = Uploadcare::user_agent(options)
 
-          frd.response :raise_error
-          frd.response :parse_json
+          # order of middleware matters!
+
+          # url_encoded changes request body and thus should be before
+          # uploadcare_auth which uses it to sign requests when secure auth
+          # strategy is being used
+          frd.request :url_encoded
+          frd.request :uploadcare_auth, auth_strategy
+
+          frd.response :uploadcare_raise_error
+          frd.response :follow_redirects, limit: 3, callback: lambda{|old, env| auth_strategy.apply(env) }
+          frd.response :uploadcare_parse_json
+
+          frd.adapter :net_http # actually, default adapter, just to be clear
         end
       end
+
     end
   end
 end

--- a/lib/uploadcare/rest/connections/upload_connection.rb
+++ b/lib/uploadcare/rest/connections/upload_connection.rb
@@ -12,8 +12,8 @@ module Uploadcare
           frd.adapter :net_http
           frd.headers['User-Agent'] = Uploadcare::user_agent(options)
 
-          frd.response :raise_error
-          frd.response :parse_json
+          frd.response :uploadcare_raise_error
+          frd.response :uploadcare_parse_json
         end
       end
     end

--- a/lib/uploadcare/rest/middlewares/auth_middleware.rb
+++ b/lib/uploadcare/rest/middlewares/auth_middleware.rb
@@ -1,0 +1,24 @@
+require 'faraday'
+
+module Uploadcare
+  module Connections
+    module Request
+      class Auth < Faraday::Middleware
+        attr_reader :auth_strategy
+
+        def initialize(app=nil, auth_strategy)
+          @auth_strategy = auth_strategy
+          super(app)
+        end
+
+        def call(env)
+          auth_strategy.apply(env)
+          @app.call(env)
+        end
+
+      end
+    end
+  end
+end
+
+Faraday::Request.register_middleware uploadcare_auth: Uploadcare::Connections::Request::Auth

--- a/lib/uploadcare/rest/middlewares/parse_json_middleware.rb
+++ b/lib/uploadcare/rest/middlewares/parse_json_middleware.rb
@@ -30,4 +30,4 @@ module Uploadcare
   end
 end
 
-Faraday::Response.register_middleware :parse_json => Uploadcare::Connections::Response::ParseJson
+Faraday::Response.register_middleware :uploadcare_parse_json => Uploadcare::Connections::Response::ParseJson

--- a/lib/uploadcare/rest/middlewares/raise_error_middleware.rb
+++ b/lib/uploadcare/rest/middlewares/raise_error_middleware.rb
@@ -7,7 +7,7 @@ module Uploadcare
         def on_complete(response)
           @error_codes = Uploadcare::Error.errors.keys
           @status = response[:status]
-          
+
           if @error_codes.include?(@status)
             error = Uploadcare::Error.errors[@status].new
             fail(error)
@@ -18,4 +18,4 @@ module Uploadcare
   end
 end
 
-Faraday::Response.register_middleware :raise_error => Uploadcare::Connections::Response::RaiseError
+Faraday::Response.register_middleware :uploadcare_raise_error => Uploadcare::Connections::Response::RaiseError

--- a/spec/resources/file_spec.rb
+++ b/spec/resources/file_spec.rb
@@ -109,14 +109,4 @@ describe Uploadcare::Api::File do
     result.should be_kind_of(Hash)
     result["type"].should == "file"
   end
-
-
-  def retry_if(error, retries=3, &block)
-    block.call
-  rescue error
-    raise if retries <= 0
-    sleep 0.2
-    retry_if(error, retries-1, &block)
-  end
-
 end

--- a/spec/rest/api_connection_spec.rb
+++ b/spec/rest/api_connection_spec.rb
@@ -3,17 +3,66 @@ require 'uri'
 require 'socket'
 
 describe Uploadcare::Connections::ApiConnection do
-  before(:all) do
-    @settings = Uploadcare.default_settings
+  let(:settings){ Uploadcare.default_settings }
+
+  it 'is initializable with default settings' do
+    expect {described_class.new(settings)}.to_not raise_error
   end
 
-  it 'should initialize api connection' do
-    expect {Uploadcare::Connections::ApiConnection.new(@settings)}.to_not raise_error
+
+  describe 'default request headers' do
+    subject{ described_class.new(settings).headers }
+
+    it 'includes correct Accept header' do
+      expected = "application/vnd.uploadcare-v#{settings[:api_version]}+json"
+      expect(subject['Accept']).to eq expected
+    end
+
+    it 'includes correct User-Agent header' do
+      expected = Uploadcare::user_agent(settings)
+      expect(subject['User-Agent']).to eq expected
+    end
   end
 
-  it 'should use ParseJson and RaiseError middlewares' do
-    connection = Uploadcare::Connections::ApiConnection.new(@settings)
-    connection.builder.handlers.include?(Uploadcare::Connections::Response::ParseJson).should == true
-    connection.builder.handlers.include?(Uploadcare::Connections::Response::RaiseError).should == true
+
+  describe 'middleware' do
+    subject{ described_class.new(settings).builder.handlers }
+
+    it 'uses Request::Auth middleware' do
+      expect(subject).to include(Uploadcare::Connections::Request::Auth)
+    end
+
+    it 'uses Response::ParseJson middleware' do
+      expect(subject).to include(Uploadcare::Connections::Response::ParseJson)
+    end
+
+    it 'uses Response::RaiseError middleware' do
+      expect(subject).to include(Uploadcare::Connections::Response::RaiseError)
+    end
+  end
+
+
+  describe 'auth scheme' do
+    it 'uses simple auth when auth_scheme: :simple setting is provided' do
+      expect(Uploadcare::Connections::Auth::Simple).to receive(:new)
+      described_class.new(settings.merge(auth_scheme: :simple))
+    end
+
+    it 'uses secure auth when auth_scheme: :secure setting is provided' do
+      expect(Uploadcare::Connections::Auth::Secure).to receive(:new)
+      described_class.new(settings.merge(auth_scheme: :secure))
+    end
+
+    it 'raises KeyError when :auth_scheme options is not provided' do
+      expect{
+        described_class.new(settings.reject{|k,_| k == :auth_scheme})
+      }.to raise_error(KeyError)
+    end
+
+    it 'raises ArgumentError when provided :auth_scheme is unknown' do
+      expect{
+        described_class.new(settings.merge(auth_scheme: :unknown))
+      }.to raise_error(ArgumentError)
+    end
   end
 end

--- a/spec/rest/auth/secure_spec.rb
+++ b/spec/rest/auth/secure_spec.rb
@@ -1,0 +1,66 @@
+require 'spec_helper'
+
+describe Uploadcare::Connections::Auth::Secure do
+  describe '#apply' do
+    let(:env){ Faraday::Env.new(:get, nil, URI::HTTP.build(host: 'example.com'), nil, {}) }
+    subject{ env.request_headers }
+
+    before(:each) do
+      described_class.new(public_key: 'pub', private_key: 'priv').apply(env)
+    end
+
+    it "adds Authorization header to env's request_headers" do
+      expect(subject).to include('Authorization')
+    end
+
+    it "adds Date header to env's request_headers" do
+      expect(subject).to include('Date')
+    end
+
+    it "uses secure authorization" do
+      expect(subject['Authorization']).to match /Uploadcare pub:.+/
+    end
+  end
+
+  describe 'signature' do
+    let(:uri){ URI::HTTP.build(host: 'example.com', path: '/path', query: 'test=1') }
+    let(:headers){ {'Content-Type' => 'application/x-www-form-urlencoded'} }
+    let(:env){ Faraday::Env.new(:post, 'url=encoded&test=body', uri, nil, headers) }
+
+    subject{ env.request_headers }
+
+    before(:each) do
+      allow(Time).to receive(:now).and_return(Time.parse('2017.02.02 12:58:50 +0000'))
+      described_class.new(public_key: 'pub', private_key: 'priv').apply(env)
+    end
+
+    it "counts signature correctly" do
+      expected = '71b61ed67d16f48d2e46a4ee72ca12025aeb8d1f'
+      expect(subject['Authorization']).to eq "Uploadcare pub:#{expected}"
+    end
+  end
+
+
+  describe 'integration' do
+    let(:api){ Uploadcare::Api.new(auth_scheme: :secure) }
+    let(:file){ api.upload IMAGE_URL }
+
+    before(:each) do
+      # ensure that secure auth is being used
+      expect_any_instance_of(described_class).to receive(:apply).at_least(4).times.and_call_original
+    end
+
+    it 'auth works with real requests' do
+      # request with url params
+      expect{ api.get('/files/', limit: 1) }.not_to raise_error
+      # request with an url-encoded body
+      expect{
+        retry_if(Uploadcare::Error::RequestError::BadRequest) do
+          api.post('/files/', source: file.uuid)
+        end
+      }.not_to raise_error
+      # request with an empty body and a redirect
+      expect{ api.delete("/files/#{file.uuid}/storage/") }.not_to raise_error
+    end
+  end
+end

--- a/spec/rest/auth/simple_spec.rb
+++ b/spec/rest/auth/simple_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe Uploadcare::Connections::Auth::Simple do
+  let(:env){ Faraday::Env.new(nil, nil, nil, nil, {}) }
+  subject{ described_class.new(public_key: 'pub', private_key: 'priv') }
+
+  describe 'apply' do
+    it "adds Authorization header to env's request_headers" do
+      subject.apply(env)
+      expect(env.request_headers).to include('Authorization')
+    end
+
+    it "sets Authorization header's value correctly" do
+      subject.apply(env)
+      expect(env.request_headers['Authorization']).to eq "Uploadcare.Simple pub:priv"
+    end
+  end
+
+  describe 'integration' do
+    let(:api){ Uploadcare::Api.new(auth_scheme: :simple) }
+
+    before(:each) do
+      # ensure that simple auth is being used
+      expect_any_instance_of(described_class).to receive(:apply).and_call_original
+    end
+
+    it 'auth works with real requests' do
+      expect{ api.get('/files/') }.not_to raise_error
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,3 +22,11 @@ config_file = File.join(File.dirname(__FILE__), 'config.yml')
 if File.exists?(config_file)
   CONFIG.update Hash[YAML.parse_file(config_file).to_ruby.map{|a, b| [a.to_sym, b]}]
 end
+
+def retry_if(error, retries=5, &block)
+  block.call
+rescue error
+  raise if retries <= 0
+  sleep 0.2
+  retry_if(error, retries-1, &block)
+end


### PR DESCRIPTION
Addresses #19
Fixes #13 

Auth headers are now being set in a middleware layer that, provided with an auth strategy, applies it to a request environment (instance of Faraday::Env). This auth strategy is also being used by FaradayMiddleware::FollowRedirects middleware in a callback to reset auth headers when redirects are being followed.

Also there was an issue with our middleware naming. As @damian mentioned in #13, our middleware was being registered in Faraday globally using names like "parse_json" which could potentially interfere with other gems if they'll choose te same names for their middleware. I've added an "uploadcare_" prefix to our middleware names so now they are namespaced.