### PR TITLE
Suppport all options for file copying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### 1.1.0
 
+- Added to new methods to Uploadcare::Api::File, #internal_copy and #external_copy.
 - Added support of [secure authorization](https://uploadcare.com/documentation/rest/#request) for REST API. It is now used by default (can be overriden in config)
 - Fixed middleware names that could break other gems ([#13](https://github.com/uploadcare/uploadcare-ruby/issues/13}).
 

--- a/README.md
+++ b/README.md
@@ -270,6 +270,94 @@ Until operations wrapper is released the best way for you to manage operation is
 # or something like that
 ```
 
+### Copying files
+
+Our API allows you to create copies of a file. There are several options for that.
+
+First of all, you can make a copy in Uploadcare storage:
+
+```ruby
+@uc_file.internal_copy
+
+# =>
+{
+  "type"=>"file",
+  "result"=> {
+    "uuid"=>"a191a3df-2c43-4939-9590-784aa371ad6d",
+    "original_file_url"=>"https://ucarecdn.com/a191a3df-2c43-4939-9590-784aa371ad6d/19xldj.jpg",
+    "image_info"=>nil,
+    "datetime_stored"=>nil,
+    "mime_type"=>"application/octet-stream",
+    "is_ready"=>true,
+    "url"=>"https://api.uploadcare.com/files/a191a3df-2c43-4939-9590-784aa371ad6d/",
+    "original_filename"=>"19xldj.jpg",
+    "datetime_uploaded"=>"2017-02-10T14:14:18.690581Z",
+    "size"=>0,
+    "is_image"=>nil,
+    "datetime_removed"=>nil,
+    "source"=>"/4ea293d5-153f-422f-a24e-350237109606/"
+  }
+}
+```
+
+A copy becomes a separate file with its own UUID and attributes.
+
+The only (optional) argument this method takes is an options hash. Available options are:
+
+- *store*
+
+  By default copy is being created unstored, so it will be deleted within 24 hours. To create a stored copy pass `store: true` option to `#internal_copy` method.
+
+  Example:
+
+  ```ruby
+  @uc_file.internal_copy(store: true)
+  ```
+
+- *strip_operations*
+
+  If your file is an image and any operations are applied to it, then by default all of them will be also applied to a copy. You can override this passing `strip_operations: true` to `#internal_copy` method.
+
+  Example:
+
+  ```ruby
+  file = @api.file "https://ucarecdn.com/24626d2f-3f23-4464-b190-37115ce7742a/-/resize/50x50/"
+  file.internal_copy
+  # => This will trigger POST /files/ with {"source": "https://ucarecdn.com/24626d2f-3f23-4464-b190-37115ce7742a/-/resize/50x50/"} in body
+  file.internal_copy(strip_operations: true)
+  # => This will trigger POST /files/ with {"source": "https://ucarecdn.com/24626d2f-3f23-4464-b190-37115ce7742a/"} in body
+  ```
+
+Secondly, you can copy your file to a custom storage.
+
+```ruby
+@uc_file.external_copy('my_custom_storage_name')
+
+# => 
+{
+  "type"=>"url",
+  "result"=>"s3://my_bucket_name/c969be02-9925-4a7e-aa6d-b0730368791c/view.png"
+}
+```
+
+First argument of this method is a name of a custom storage you wish to copy your file to.
+
+Second argument is an (optional) options hash. Available options are:
+
+  - *make_public*
+
+  Make a copy available via public links. Can be either `true` or `false`
+
+  - *pattern*
+
+  Name pattern for a copy. If parameter is omitted, custom storage pattern is used.
+
+  - *strip_operations*
+
+  Same as for `#internal_copy`
+
+You can read more about about storages here: <https://uploadcare.com/documentation/storages/>, about copying files here: https://uploadcare.com/documentation/rest/#files-post
+
 ## File list and pagination
 File list is a paginated collection of files for you project. You could read more at https://uploadcare.com/documentation/rest/#pagination.
 In our gem file list is a single page containing 20 (by default, value may change) files and some methods for navigating through pages.

--- a/lib/uploadcare/resources/file.rb
+++ b/lib/uploadcare/resources/file.rb
@@ -5,7 +5,7 @@ module Uploadcare
     class File < OpenStruct
       def initialize api, uuid_or_cdn_url, data=nil
         result = Uploadcare::Parser.parse_file_string uuid_or_cdn_url
-        
+
         file = {uuid: result.uuid, operations: result.operations}
 
         @api = api
@@ -65,7 +65,7 @@ module Uploadcare
       def store
         data = @api.put "/files/#{uuid}/storage/"
         set_data data
-        self 
+        self
       end
 
       # nil is returning if there is no way to say for sure
@@ -99,6 +99,28 @@ module Uploadcare
         data[:target] = target if target
         data[:source] = self.cdn_url_with_operations if with_operations
         data[:source] = self.cdn_url_without_operations unless with_operations
+
+        @api.post "/files/", data
+      end
+
+      # Create a copy of the file in a default storage
+      def internal_copy(options={})
+        data = {
+          source: cdn_url(!options.fetch(:strip_operations){ false }),
+          store: options.fetch(:store){ nil }
+        }.reject{|_,v| v.nil?}
+
+        @api.post "/files/", data
+      end
+
+      # Copy file to a custom storage
+      def external_copy(target, options={})
+        data = {
+          source: cdn_url(!options.fetch(:strip_operations){ false }),
+          target: target,
+          pattern: options.fetch(:pattern){ nil },
+          make_public: options.fetch(:make_public){ nil },
+        }.reject{|_,v| v.nil?}
 
         @api.post "/files/", data
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,6 +23,12 @@ if File.exists?(config_file)
   CONFIG.update Hash[YAML.parse_file(config_file).to_ruby.map{|a, b| [a.to_sym, b]}]
 end
 
+if CONFIG[:public_key] == 'demopublickey'
+  RSpec.configure do |c|
+    c.before(:example, :payed_feature){ skip "Unavailable for demo account" }
+  end
+end
+
 def retry_if(error, retries=5, &block)
   block.call
 rescue error


### PR DESCRIPTION
@dmitry-mukhin I've added two separate file copying methods, `#internal_copy` and `#external_copy`. I'll rename them when you deside on propper names and before merging this PR.

-----

Note that new methods get their optional arguments as an options hash, which is inconsistent with common practice for this library, but provides some benefits:

- You can add new options to such a methods without breaking anything, as you are not tide to arguments order anymore
- You can deprecate individual options instead of deprecating the whole method and creating new ones

I need your confirmation for that.

-----

I'll add deprecation of `File#copy` and a fix to use pub/priv keys from Travis env vars in specs in 2 separate PRs.