### PR TITLE
Deprecate Uploadcare::Api::File#copy method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### 1.1.0
 
+- Deprecated `Uploadcare::Api::File#copy` in favor of `#internal_copy` and `#external_copy`.
 - Added to new methods to Uploadcare::Api::File, #internal_copy and #external_copy.
 - Added support of [secure authorization](https://uploadcare.com/documentation/rest/#request) for REST API. It is now used by default (can be overriden in config)
 - Fixed middleware names that could break other gems ([#13](https://github.com/uploadcare/uploadcare-ruby/issues/13}).

--- a/lib/uploadcare/resources/file.rb
+++ b/lib/uploadcare/resources/file.rb
@@ -95,6 +95,7 @@ module Uploadcare
       # copy file to target location
       # note what file copied with operations
       def copy with_operations=true, target=nil
+        warn "[DEPRECATION] `copy` is deprecated.  Please use `internal_copy` or `external_copy` instead."
         data = Hash.new
         data[:target] = target if target
         data[:source] = self.cdn_url_with_operations if with_operations

--- a/lib/uploadcare/resources/file.rb
+++ b/lib/uploadcare/resources/file.rb
@@ -95,7 +95,7 @@ module Uploadcare
       # copy file to target location
       # note what file copied with operations
       def copy with_operations=true, target=nil
-        warn "[DEPRECATION] `copy` is deprecated.  Please use `internal_copy` or `external_copy` instead."
+        warn "[DEPRECATION] `copy` is deprecated and will be removed in version 3.0.  Please use `internal_copy` or `external_copy` instead."
         data = Hash.new
         data[:target] = target if target
         data[:source] = self.cdn_url_with_operations if with_operations


### PR DESCRIPTION
... in favor of #internal_copy and #external_copy

addresses #22