### PR TITLE
Make File:external_copy test pass in Travis

### DIFF
--- a/spec/resources/file_spec.rb
+++ b/spec/resources/file_spec.rb
@@ -158,16 +158,16 @@ describe Uploadcare::Api::File do
 
 
   describe '#external_copy' do
-    let(:target){ 'test' }
+    let(:target){ 'test_storage' }
 
     describe 'integration', :payed_feature do
       it 'creates an external copy of the file' do
         response = retry_if(Uploadcare::Error::RequestError::BadRequest) do
-                     @file.external_copy(target: target)
+                     @file.external_copy(target)
                    end
 
         expect( response['type'] ).to eq 'url'
-        expect( response['result']['uuid'] ).not_to eq @file.uuid
+        expect( response['result'] ).to match(URI.regexp)
       end
     end
 

--- a/spec/resources/file_spec.rb
+++ b/spec/resources/file_spec.rb
@@ -158,7 +158,7 @@ describe Uploadcare::Api::File do
 
 
   describe '#external_copy' do
-    let(:target){ 'test_storage' }
+    let(:target){ 'with-prefix' }
 
     describe 'integration', :payed_feature do
       it 'creates an external copy of the file' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,7 +7,10 @@ require 'rspec'
 require 'uploadcare'
 require 'yaml'
 
-CONFIG = Uploadcare.default_settings
+CONFIG = Uploadcare.default_settings.merge!(
+  public_key: ENV['UPLOADCARE_PUBLIC_KEY'] || 'demopublickey',
+  private_key: ENV['UPLOADCARE_SECRET_KEY'] || 'demoprivatekey',
+)
 UUID_REGEX = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/
 
 API = Uploadcare::Api.new(CONFIG)


### PR DESCRIPTION
Now there are specs for features enabled only for a payed accounts. We want to test all our features, so we should set up an account which have enough permissions to run tests. It's credentials should be added to uploadcare/uploadcare-ruby repo setting in Travis. Specs will expect them to be put into `UPLOADCARE_PUBLIC_KEY` and `UPLOADCARE_SECRET_KEY` env variables. If there isn't any, specs will use demo account.

All specs/spec groups that test payed features should be tagged with :payed_feature. This will make them to run only for non-demo accounts.

-----

Also I've found a bug in a test.