### PR TITLE
fix NoMethodErrors in Auth::Secure and NameError in spec/resources/file_spec.rb

### DIFF
--- a/lib/uploadcare/rest/auth/secure.rb
+++ b/lib/uploadcare/rest/auth/secure.rb
@@ -1,3 +1,5 @@
+require 'time'
+
 module Uploadcare
   module Connections
     module Auth

--- a/spec/resources/file_spec.rb
+++ b/spec/resources/file_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 require 'uri'
 require 'socket'
+require 'securerandom'
 
 describe Uploadcare::Api::File do
   before :each do


### PR DESCRIPTION
New versions of bundler (1.14.5, 1.12.6) don't require 'time' and 'securerandom' anymore. According to a comment [here](https://github.com/bundler/bundler/issues/5470#issuecomment-282121120) by one of bundler's maintainers, it is somehow related to upcoming changes in ruby 2.5.

This causes `NoMethodError`s in secure auth implementation (uses `Time#rfc2822`) and `NameError`s in `spec/resources/file_spec.rb' (uses `SecureRandom`).

Ruby 2.5 is currenlty not even in beta, so things may change, but the fact is that our gem is broken with this new versions of bundler. This is the fix.