### PR TITLE
Batch file storage/deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### 2.0.0
 
+- All POST/PUT/DELETE params are now being sent as json instead of being form-encoded
+- Added methods to store/delete multiple files at once: `Uploadcare::Api#store_files` & `Uploadcare::Api#delete_files`
 - Changed pagination implementation for files and groups
 - Moved to API v0.5
 

--- a/README.md
+++ b/README.md
@@ -388,10 +388,10 @@ with Uploadcare.
 
 ### File lists
 
-`Uploadcare::FileList` represents the whole collection of files (or it's subset) and privides a way to iterate through it, making pagination transparent. FileList objects can be created using `Uploadcare::Api#file_list` method.
+`Uploadcare::Api::FileList` represents the whole collection of files (or it's subset) and privides a way to iterate through it, making pagination transparent. FileList objects can be created using `Uploadcare::Api#file_list` method.
 
 ```ruby
-@list = @api.file_list # => instance of Uploadcare::FileList
+@list = @api.file_list # => instance of Uploadcare::Api::FileList
 ```
 
 This method accepts some options to controll which files should be fetched and how they should be fetched:
@@ -415,7 +415,7 @@ options = {
 @list.options # => same as options hash above, but frozen
 ```
 
-`Uploadcare::FileList` implements Enumerable interface and holds a collection of `Uploadcare::File` objects, as well as some meta information.
+`Uploadcare::Api::FileList` implements Enumerable interface and holds a collection of `Uploadcare::Api::File` objects, as well as some meta information.
 
 ```ruby
 @list = @api.file_list
@@ -428,7 +428,7 @@ options = {
 # }
 
 # Enumerable interface
-@list.first(5) # => array of 5 x Uploadcare::File
+@list.first(5) # => array of 5 x Uploadcare::Api::File
 @list.each{|file| puts file.original_filename}
 @list.map{|file| file.uuid}
 @list.reduce(0){|overall_size, file| overall_size += file.size}
@@ -444,8 +444,8 @@ Currently loaded files are available through `FileList#objects` or via `:[]`. `F
 @list.loaded # => 5
 @list.fully_loaded? # => false
 
-@list.objects # => array of 5 x Uploadcare::File
-@list[0] # => instance of Uploadcare::File
+@list.objects # => array of 5 x Uploadcare::Api::File
+@list[0] # => instance of Uploadcare::Api::File
 
 @list.first(5) # won't load anything, because 5 files are already loaded
 @list.first(6) # will load the next page
@@ -472,6 +472,31 @@ end # => RuntimeError
 
 @list.loaded # => 20
 ```
+
+
+### Store / delete multiple files at once
+
+There are two methods to do that: `Uploadcare::Api#store_files` and
+`Uploadcare::Api#delete_files`. Both of them accept either a list of
+UUIDs/`Uploadcare::Api::File`s or an `Uploadcare::Api::FileList`:
+
+```ruby
+uuids_to_store = ['f5c477e0-22af-469d-859a-712e14e14361', 'ec72c6eb-5ea8-4057-a009-52ffffb27c94']
+@api.store_files(uuids_to_store)
+
+old_files = @api.file_list(stored: true, ordering: '-datetime_uploaded', from: "2015-01-01T00:00:00")
+@api.delete_files(old_files)
+```
+
+Our API supports up to 100 files per request. Calling `#store_files` or
+`#delete_files` with more than 100 files at once will cause multiple store/delete
+requests because files will be divided into batches of 100 in order to comply
+with this limitation.
+
+Note that when you pass in an `Uploadcare::Api::FileList` additional requests can
+potentially be made because FileList may need to load files first. Depending on
+the value of the `:limit` option with which the FileList was created, it may
+perform more than one load request before each store/delete request.
 
 
 ### `Group` object
@@ -525,11 +550,11 @@ Check out our docs to learn more about
 
 ### Group lists
 
-`Uploadcare::GroupList` represents a group collection. It works in a same way as `Uploadcare::FileList` does, but with groups. 
+`Uploadcare::Api::GroupList` represents a group collection. It works in a same way as `Uploadcare::Api::FileList` does, but with groups. 
 
 ```ruby
-@list = @api.group_list(limit: 10) # => instance of Uploadcare::GroupList
-@list[0] # => instance of Uploadcare::Group
+@list = @api.group_list(limit: 10) # => instance of Uploadcare::Api::GroupList
+@list[0] # => instance of Uploadcare::Api::Group
 ```
 
 The only thing that differs is an available options list: 

--- a/README.md
+++ b/README.md
@@ -476,28 +476,26 @@ end # => RuntimeError
 
 ### Store / delete multiple files at once
 
-There are two methods to do that: `Uploadcare::Api#store_files` and
-`Uploadcare::Api#delete_files`. Both of them accept either a list of
-UUIDs/`Uploadcare::Api::File`s or an `Uploadcare::Api::FileList`:
+There are two methods to do so: `Uploadcare::Api#store_files` and
+`Uploadcare::Api#delete_files`. Both of them accept a list of either
+UUIDs or `Uploadcare::Api::File`s:
 
 ```ruby
 uuids_to_store = ['f5c477e0-22af-469d-859a-712e14e14361', 'ec72c6eb-5ea8-4057-a009-52ffffb27c94']
 @api.store_files(uuids_to_store)
+# => {'status' => 'ok', 'problems' => {}, 'result' => [{...}, {...}]}
 
 old_files = @api.file_list(stored: true, ordering: '-datetime_uploaded', from: "2015-01-01T00:00:00")
-@api.delete_files(old_files)
+old_files.each_slice(100) do |batch|
+  response = @api.delete_files(batch)
+  # Do something with response if you need to
+end
 ```
 
 Our API supports up to 100 files per request. Calling `#store_files` or
-`#delete_files` with more than 100 files at once will cause multiple store/delete
-requests because files will be divided into batches of 100 in order to comply
-with this limitation.
+`#delete_files` with more than 100 files at once will cause an ArgumentError.
 
-Note that when you pass in an `Uploadcare::Api::FileList` additional requests can
-potentially be made because FileList may need to load files first. Depending on
-the value of the `:limit` option with which the FileList was created, it may
-perform more than one load request before each store/delete request.
-
+For more details see our [documentation on batch file storage/deletion](https://uploadcare.com/documentation/rest/#files-storage)
 
 ### `Group` object
 

--- a/lib/uploadcare.rb
+++ b/lib/uploadcare.rb
@@ -2,8 +2,8 @@ require 'faraday'
 require 'json'
 require 'ostruct'
 
-require 'uploadcare/api'
-require 'uploadcare/version'
+require_relative 'uploadcare/api'
+require_relative 'uploadcare/version'
 
 module Uploadcare
   DEFAULT_SETTINGS = {

--- a/lib/uploadcare/api.rb
+++ b/lib/uploadcare/api.rb
@@ -21,5 +21,6 @@ module Uploadcare
     include Uploadcare::FileListApi
     include Uploadcare::GroupApi
     include Uploadcare::GroupListApi
+    include Uploadcare::FileStorageApi
   end
 end

--- a/lib/uploadcare/api/file_storage_api.rb
+++ b/lib/uploadcare/api/file_storage_api.rb
@@ -1,0 +1,30 @@
+module Uploadcare
+  module FileStorageApi
+    BATCH_SIZE = 100
+    UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+
+    def store_files(objects)
+      in_batches(objects) { |batch| put "/files/storage/", to_uuids(batch) }
+    end
+
+    def delete_files(objects)
+      in_batches(objects) { |batch| delete "/files/storage/", to_uuids(batch) }
+    end
+
+    private
+
+    def in_batches(enum)
+      enum.each_slice(BATCH_SIZE) { |batch| yield batch }
+    end
+
+    def to_uuids(objects)
+      objects.map do |object|
+        case object
+        when Uploadcare::Api::File then object.uuid
+        when UUID_REGEX then object
+        else raise(ArgumentError, "Unable to convert object to uuid: #{object}")
+        end
+      end
+    end
+  end
+end

--- a/lib/uploadcare/api/file_storage_api.rb
+++ b/lib/uploadcare/api/file_storage_api.rb
@@ -1,21 +1,25 @@
 module Uploadcare
   module FileStorageApi
-    BATCH_SIZE = 100
+    MAX_BATCH_SIZE = 100
     UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
 
     def store_files(objects)
-      in_batches(objects) { |batch| put "/files/storage/", to_uuids(batch) }
+      if objects.size > MAX_BATCH_SIZE
+        raise ArgumentError, "Up to #{MAX_BATCH_SIZE} files are supported per request, #{objects.size} given"
+      end
+
+      put "/files/storage/", to_uuids(objects)
     end
 
     def delete_files(objects)
-      in_batches(objects) { |batch| delete "/files/storage/", to_uuids(batch) }
+      if objects.size > MAX_BATCH_SIZE
+        raise ArgumentError, "Up to #{MAX_BATCH_SIZE} files are supported per request, #{objects.size} given"
+      end
+
+      delete "/files/storage/", to_uuids(objects)
     end
 
     private
-
-    def in_batches(enum)
-      enum.each_slice(BATCH_SIZE) { |batch| yield batch }
-    end
 
     def to_uuids(objects)
       objects.map do |object|

--- a/lib/uploadcare/resources/group_list.rb
+++ b/lib/uploadcare/resources/group_list.rb
@@ -7,7 +7,7 @@ module Uploadcare
       private
 
       def to_resource(api, group_data)
-        Uploadcare::Api::Group.new @api, group_data["id"], group_data
+        Uploadcare::Api::Group.new api, group_data["id"], group_data
       end
     end
   end

--- a/lib/uploadcare/resources/resource_list.rb
+++ b/lib/uploadcare/resources/resource_list.rb
@@ -26,8 +26,6 @@ module Uploadcare
         self
       end
 
-      # TODO: #delete and #store methods
-
       def total
         meta['total']
       end
@@ -41,6 +39,7 @@ module Uploadcare
       end
 
       private
+
       attr_reader :api
 
       def build_data(data_hash)

--- a/lib/uploadcare/rest/connections/api_connection.rb
+++ b/lib/uploadcare/rest/connections/api_connection.rb
@@ -14,10 +14,10 @@ module Uploadcare
 
           # order of middleware matters!
 
-          # url_encoded changes request body and thus should be before
+          # :json middleware changes request body and thus should be before
           # uploadcare_auth which uses it to sign requests when secure auth
           # strategy is being used
-          frd.request :url_encoded
+          frd.request :json
           frd.request :uploadcare_auth, auth_strategy
 
           frd.response :uploadcare_raise_error
@@ -26,6 +26,27 @@ module Uploadcare
 
           frd.adapter :net_http # actually, default adapter, just to be clear
         end
+      end
+
+      # NOTE: Faraday doesn't support body in DELETE requests, but
+      # Uploadcare API v0.5 requires clients to send array of UUIDs with
+      # `DELETE /files/storage/` requests.
+      #
+      # This is on override of the original Faraday::Connection#delete method.
+      #
+      # As for now, there are no DELETE requests in Uploadcare REST API
+      # which require params to be sent as URI params, so for simplicity
+      # this method send all params in a body.
+      def delete(url = nil, params = nil, headers = nil)
+        run_request(:delete, url, nil, headers) { |request|
+          # Original line from Faraday::Connection#delete method
+          # request.params.update(params) if params
+
+          # Monkey patch
+          request.body = params if params
+
+          yield(request) if block_given?
+        }
       end
 
     end

--- a/lib/uploadcare/rest/connections/upload_connection.rb
+++ b/lib/uploadcare/rest/connections/upload_connection.rb
@@ -9,11 +9,12 @@ module Uploadcare
         super ssl: { ca_path: ca_path }, url: options[:upload_url_base] do |frd|
           frd.request :multipart
           frd.request :url_encoded
-          frd.adapter :net_http
           frd.headers['User-Agent'] = Uploadcare::user_agent(options)
 
           frd.response :uploadcare_raise_error
           frd.response :uploadcare_parse_json
+
+          frd.adapter :net_http
         end
       end
     end

--- a/spec/api/file_storage_api_spec.rb
+++ b/spec/api/file_storage_api_spec.rb
@@ -1,0 +1,76 @@
+require 'spec_helper'
+
+describe Uploadcare::FileStorageApi do
+  let(:api){ API }
+  let(:file){ api.file_list(limit: 1).first || api.upload(IMAGE_URL) }
+
+  shared_examples 'batch action on files' do
+    let(:uuids) { ["dc2c175d-a3b5-4435-b4f4-fae77bbe5597", "cea319aa-6e17-4172-8722-8dd7c459a523"] }
+    let(:files) { uuids.map { |uuid| Uploadcare::Api::File.new(api, uuid) } }
+    let(:api_endpoint) { "/files/storage/" }
+
+    it 'accepts array of uuids' do
+      expect(api).to receive(http_method)
+      expect { subject.call(uuids) }.not_to raise_error
+    end
+
+    it 'accepts enumerable containing Uploadcare::Api::File objects' do
+      expect(api).to receive(http_method)
+      expect { subject.call(files) }.not_to raise_error
+    end
+
+    it 'converts Uploadcare::Api::File-s to uuids' do
+      expect(api).to receive(http_method).with(api_endpoint, uuids)
+      subject.call(files)
+    end
+
+    context 'when input contains something other than UUIDs or Uploadcare::Api::File-s' do
+      it 'raises ArgumentError' do
+        ['not-an-uuid', nil, 1].each do |wrong_input_value|
+          expect { subject.call([wrong_input_value]) }.to raise_error(ArgumentError)
+        end
+      end
+    end
+
+    it 'breaks large input arrays into batches' do
+      stub_const("Uploadcare::FileStorageApi::BATCH_SIZE", 1)
+
+      expect(api).to receive(http_method).with(api_endpoint, [uuids[0]]).ordered
+      expect(api).to receive(http_method).with(api_endpoint, [uuids[1]]).ordered
+
+      subject.call(uuids)
+    end
+  end
+
+  describe '#store_files' do
+    let(:http_method) { :put }
+    subject { ->(objects) { api.store_files(objects) } }
+
+    it_behaves_like 'batch action on files'
+
+    describe 'integration test' do
+      before { file.delete if file.stored? }
+
+      it 'stores files with given uuids' do
+        expect { api.store_files([file]) }
+          .to change { file.load!.stored? }.from(false).to(true)
+      end
+    end
+  end
+
+  describe '#delete_files' do
+    let(:http_method) { :delete }
+    subject { ->(objects) { api.delete_files(objects) } }
+
+    it_behaves_like 'batch action on files'
+
+    describe 'integration test' do
+      before { file.store if file.deleted? }
+
+      it 'deletes files with given uuids' do
+        expect { api.delete_files([file]) }
+          .to change { file.load!.deleted? }.from(false).to(true)
+      end
+    end
+  end
+end

--- a/spec/resources/group_list_spec.rb
+++ b/spec/resources/group_list_spec.rb
@@ -1,6 +1,4 @@
 require 'spec_helper'
-# require 'uri'
-# require 'socket'
 
 describe Uploadcare::Api::GroupList do
   before :all do

--- a/spec/resources/group_list_spec.rb
+++ b/spec/resources/group_list_spec.rb
@@ -5,9 +5,8 @@ describe Uploadcare::Api::GroupList do
     @api = API
 
     # ensure that current project has at least three groups
-    if @api.get('/groups/', limit: 3)['results'].size < 3
-      (3 - count).times{ @api.create_group([@api.upload(IMAGE_URL)]) }
-    end
+    count = @api.get('/groups/', limit: 3)['results'].size
+    (3 - count).times{ @api.create_group([@api.upload(IMAGE_URL)]) } if count < 3
 
     @list = @api.group_list(limit: 1)
   end

--- a/spec/shared/resource_list.rb
+++ b/spec/shared/resource_list.rb
@@ -88,7 +88,6 @@ shared_examples 'resource list' do
       i, uuids = 0, []
       subject.each{|object| uuids << object.uuid; i+=1; break if i >= 2 }
 
-      expect(uuids.size).to eq 2
       expect(uuids).to eq([subject[0].uuid, subject[1].uuid])
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -34,10 +34,18 @@ end
 
 Dir[File.join(File.dirname(__FILE__), 'shared/*.rb')].each{|path| require path}
 
-def retry_if(error, retries=5, &block)
+def retry_if(error, retries=10, &block)
   block.call
 rescue error
   raise if retries <= 0
   sleep 0.2
   retry_if(error, retries-1, &block)
+end
+
+def wait_until_ready(file)
+  unless file.is_ready
+    sleep 0.2
+    file.load_data!
+    wait_until_ready(file)
+  end
 end


### PR DESCRIPTION
closes #21 

I've added two new methods:

- `Uploadcare::Api#store_files`
- `Uploadcare::Api#delete_files`

Both of them accept either an array containing UUIDs/`Uploadcare::Api::File`s or an `Uploadcare::Api::FileList`.

**Notes**

Please note the changes in [lib/uploadcare/rest/connections/api_connection.rb][1]. The `DELETE /files/storage/` endpoint accepts UUIDs of files to be deleted. It accepts them in the form of a json array in request's body. As far as I know, there is no way to send an unamed array in a url-encoded format (which we use now), so I was forced to change the request params encoding strategy to `json`. Tests are passing, so I think this won't cause any issues.

[1]: https://github.com/uploadcare/uploadcare-ruby/pull/32/files#diff-345ba88fe13398095cf34b4a9addd26f