### PR TITLE
Enables automatic storing when uploading file

### DIFF
--- a/lib/uploadcare/rest/connections/upload_connection.rb
+++ b/lib/uploadcare/rest/connections/upload_connection.rb
@@ -1,4 +1,4 @@
-  require "faraday"
+require "faraday"
 
 module Uploadcare
   module Connections

--- a/lib/uploadcare/rest/connections/upload_connection.rb
+++ b/lib/uploadcare/rest/connections/upload_connection.rb
@@ -7,12 +7,6 @@ module Uploadcare
         ca_path = '/etc/ssl/certs' if File.exists?('/etc/ssl/certs')
 
         super ssl: { ca_path: ca_path }, url: options[:upload_url_base] do |frd|
-
-          #log = Logger.new $stderr
-
-          #frd.request :logger, log, bodies:true
-          #frd.response :logger, log, bodies:true
-
           frd.request :multipart
           frd.request :url_encoded
           frd.adapter :net_http

--- a/lib/uploadcare/rest/connections/upload_connection.rb
+++ b/lib/uploadcare/rest/connections/upload_connection.rb
@@ -1,4 +1,4 @@
-require "faraday"
+  require "faraday"
 
 module Uploadcare
   module Connections
@@ -7,6 +7,12 @@ module Uploadcare
         ca_path = '/etc/ssl/certs' if File.exists?('/etc/ssl/certs')
 
         super ssl: { ca_path: ca_path }, url: options[:upload_url_base] do |frd|
+
+          #log = Logger.new $stderr
+
+          #frd.request :logger, log, bodies:true
+          #frd.response :logger, log, bodies:true
+
           frd.request :multipart
           frd.request :url_encoded
           frd.adapter :net_http

--- a/spec/resources/file_spec.rb
+++ b/spec/resources/file_spec.rb
@@ -53,6 +53,12 @@ describe Uploadcare::Api::File do
     @file.is_stored?.should == true
   end
 
+  it 'should store automatically when given store=true' do
+    @stored_file = @api.upload IMAGE_URL, true
+    @stored_file.load
+    @stored_file.is_stored?.should == true
+  end
+
   it 'should delete itself' do
     expect { @file.delete }.to_not raise_error
   end

--- a/spec/resources/group_spec.rb
+++ b/spec/resources/group_spec.rb
@@ -68,6 +68,14 @@ describe Uploadcare::Api::Group do
     group_unloaded.is_stored?.should == true
   end
 
+  it "should automatically store based on params" do
+    @files = @api.upload FILES_ARY, true
+    group = @api.create_group @files
+
+    group.load
+    group.is_stored?.should == true
+  end
+
   it "group should have datetime attributes" do
     group = @api.create_group @files
     group.should respond_to(:datetime_created)

--- a/spec/resources/group_spec.rb
+++ b/spec/resources/group_spec.rb
@@ -68,7 +68,7 @@ describe Uploadcare::Api::Group do
     group_unloaded.is_stored?.should == true
   end
 
-  it "should automatically store based on params" do
+  it "should store automatically when given store=true" do
     @files = @api.upload FILES_ARY, true
     group = @api.create_group @files
 


### PR DESCRIPTION
One implementation detail is that the API will only "not store" only if the `store` param is missing or `store:0`. `store:'false'` will not work (the API will evaluate that to true and store anyway)