### PR TITLE
Improvements on file spec

### DIFF
--- a/spec/resources/file_spec.rb
+++ b/spec/resources/file_spec.rb
@@ -9,44 +9,44 @@ describe Uploadcare::Api::File do
     @file = @api.upload IMAGE_URL
   end
 
-  it 'file should be an instance of File' do
-    @file.should be_an_instance_of Uploadcare::Api::File
+  it 'is an instance of File' do
+    expect(@file).to be_an_instance_of Uploadcare::Api::File
   end
 
-  it 'should not be initialized without correct UUID given' do
+  it 'is not initialized without correct UUID given' do
     expect {Uploadcare::Api::File.new(@api, "not-uuid")}.to raise_error
   end
 
-  it 'should have valid url' do
-    @file.uuid.should match UUID_REGEX
+  it 'has a valid url' do
+    expect(@file.uuid).to match UUID_REGEX
   end
 
-  it 'should return public url' do
-    @file.should respond_to :cdn_url
-    @file.should respond_to :public_url
+  it 'returns a public url' do
+    expect(@file).to respond_to :cdn_url
+    expect(@file).to respond_to :public_url
   end
 
-  it 'public url should be valid url' do
+  it 'has a public url that is valid' do
     url = @file.cdn_url
     uri = URI.parse(url)
-    uri.should be_kind_of(URI::HTTP)
+    expect(uri).to be_kind_of(URI::HTTP)
   end
 
-  it 'should be able to load image data' do
+  it 'is able to load image data' do
     expect {@file.load_data}.to_not raise_error
   end
 
-  it 'should store itself' do
+  it 'stores itself' do
     expect { @file.store }.to_not raise_error
   end
 
-  it 'file should respond with nil for :stored? and :deleted? methods unless loaded' do
-    @file.is_loaded?.should == false
-    @file.is_stored?.should == nil
-    @file.is_deleted?.should == nil
+  it 'responds with nil for :stored? and :deleted? methods unless loaded' do
+    expect(@file.is_loaded?).to be false
+    expect(@file.is_stored?).to be_nil
+    expect(@file.is_deleted?).to be_nil
   end
 
-  it 'should be able to tell thenever file was stored' do
+  it 'is able to tell thenever file was stored' do
     @file.load
     expect(@file.stored?).to be(true)
     wait_until_ready(@file)
@@ -54,64 +54,64 @@ describe Uploadcare::Api::File do
     expect(@file.stored?).to be(false)
   end
 
-  it 'should delete itself' do
+  it 'deletes itself' do
     expect { @file.delete }.to_not raise_error
   end
 
-  it 'should be able to tell thenever file was deleted' do
+  it 'is able to tell thenever file was deleted' do
     @file.load
     @file.is_deleted?.should == false
     wait_until_ready(@file)
     @file.delete
-    @file.is_deleted?.should == true
+    expect(@file.is_deleted?).to be true
   end
 
-  it 'should construct file from uuid' do
+  it 'constructs file from uuid' do
     file = @api.file @file.uuid
-    file.should be_kind_of(Uploadcare::Api::File)
+    expect(file).to be_kind_of(Uploadcare::Api::File)
   end
 
-  it 'should construct file from cdn url' do
+  it 'constructs file from cdn url' do
     url = @file.cdn_url + "-/crop/150x150/center/-/format/png/"
     file = @api.file url
-    file.should be_kind_of(Uploadcare::Api::File)
+    expect(file).to be_kind_of(Uploadcare::Api::File)
   end
 
-  it 'shoul respond to datetime_ methods' do
+  it 'responds to datetime_ methods' do
     @file.load
-    @file.should respond_to(:datetime_original)
-    @file.should respond_to(:datetime_uploaded)
-    @file.should respond_to(:datetime_stored)
-    @file.should respond_to(:datetime_removed)
+    expect(@file).to respond_to(:datetime_original)
+    expect(@file).to respond_to(:datetime_uploaded)
+    expect(@file).to respond_to(:datetime_stored)
+    expect(@file).to respond_to(:datetime_removed)
   end
 
-  it 'should respond to datetime_uploaded' do
+  it 'responds to datetime_uploaded' do
     @file.load
-    @file.datetime_uploaded.should be_kind_of(DateTime)
+    expect(@file.datetime_uploaded).to be_kind_of(DateTime)
   end
 
-  it 'should respond to datetime_stored' do
+  it 'responds to datetime_stored' do
     @file.load
     @file.store
-    @file.datetime_stored.should be_kind_of(DateTime)
+    expect(@file.datetime_stored).to be_kind_of(DateTime)
   end
 
-  it 'should respond to datetime_removed' do
+  it 'responds to datetime_removed' do
     @file.load
     wait_until_ready(@file)
     @file.delete
-    @file.datetime_removed.should be_kind_of(DateTime)
-    @file.datetime_deleted.should be_kind_of(DateTime)
-    @file.datetime_removed.should == @file.datetime_deleted
+    expect(@file.datetime_removed).to be_kind_of(DateTime)
+    expect(@file.datetime_deleted).to be_kind_of(DateTime)
+    expect(@file.datetime_removed).to eq @file.datetime_deleted
   end
 
 
-  it 'should copy itself' do
+  it 'copies itself' do
     # This can cause "File is not ready yet" error if ran too early
     # In this case we retry it 3 times before giving up
     result = retry_if(Uploadcare::Error::RequestError::BadRequest){@file.copy}
-    result.should be_kind_of(Hash)
-    result["type"].should == "file"
+    expect(result).to be_kind_of(Hash)
+    expect(result["type"]).to eq "file"
   end
 
 

--- a/spec/resources/file_spec.rb
+++ b/spec/resources/file_spec.rb
@@ -4,112 +4,110 @@ require 'socket'
 require 'securerandom'
 
 describe Uploadcare::Api::File do
-  before :each do
-    @api = API
-    @file = @api.upload IMAGE_URL
-  end
+  let(:api) { API }
+  let(:file) { api.upload IMAGE_URL }
 
   it 'is an instance of File' do
-    expect(@file).to be_an_instance_of Uploadcare::Api::File
+    expect(file).to be_an_instance_of Uploadcare::Api::File
   end
 
   it 'is not initialized without correct UUID given' do
-    expect {Uploadcare::Api::File.new(@api, "not-uuid")}.to raise_error
+    expect {Uploadcare::Api::File.new(api, "not-uuid")}.to raise_error
   end
 
   it 'has a valid url' do
-    expect(@file.uuid).to match UUID_REGEX
+    expect(file.uuid).to match UUID_REGEX
   end
 
   it 'returns a public url' do
-    expect(@file).to respond_to :cdn_url
-    expect(@file).to respond_to :public_url
+    expect(file).to respond_to :cdn_url
+    expect(file).to respond_to :public_url
   end
 
   it 'has a public url that is valid' do
-    url = @file.cdn_url
+    url = file.cdn_url
     uri = URI.parse(url)
     expect(uri).to be_kind_of(URI::HTTP)
   end
 
   it 'is able to load image data' do
-    expect {@file.load_data}.to_not raise_error
+    expect {file.load_data}.to_not raise_error
   end
 
   it 'stores itself' do
-    expect { @file.store }.to_not raise_error
+    expect { file.store }.to_not raise_error
   end
 
   it 'responds with nil for :stored? and :deleted? methods unless loaded' do
-    expect(@file.is_loaded?).to be false
-    expect(@file.is_stored?).to be_nil
-    expect(@file.is_deleted?).to be_nil
+    expect(file.is_loaded?).to be false
+    expect(file.is_stored?).to be_nil
+    expect(file.is_deleted?).to be_nil
   end
 
   it 'is able to tell thenever file was stored' do
-    @file.load
-    expect(@file.stored?).to be(true)
-    wait_until_ready(@file)
-    @file.delete
-    expect(@file.stored?).to be(false)
+    file.load
+    expect(file.stored?).to be(true)
+    wait_until_ready(file)
+    file.delete
+    expect(file.stored?).to be(false)
   end
 
   it 'deletes itself' do
-    expect { @file.delete }.to_not raise_error
+    expect { file.delete }.to_not raise_error
   end
 
   it 'is able to tell thenever file was deleted' do
-    @file.load
-    @file.is_deleted?.should == false
-    wait_until_ready(@file)
-    @file.delete
-    expect(@file.is_deleted?).to be true
+    file.load
+    file.is_deleted?.should == false
+    wait_until_ready(file)
+    file.delete
+    expect(file.is_deleted?).to be true
   end
 
   it 'constructs file from uuid' do
-    file = @api.file @file.uuid
-    expect(file).to be_kind_of(Uploadcare::Api::File)
+    uuid_file = api.file file.uuid
+    expect(uuid_file).to be_kind_of(Uploadcare::Api::File)
   end
 
   it 'constructs file from cdn url' do
-    url = @file.cdn_url + "-/crop/150x150/center/-/format/png/"
-    file = @api.file url
+    url = file.cdn_url + "-/crop/150x150/center/-/format/png/"
+    file = api.file url
     expect(file).to be_kind_of(Uploadcare::Api::File)
   end
 
   it 'responds to datetime_ methods' do
-    @file.load
-    expect(@file).to respond_to(:datetime_original)
-    expect(@file).to respond_to(:datetime_uploaded)
-    expect(@file).to respond_to(:datetime_stored)
-    expect(@file).to respond_to(:datetime_removed)
+    file.load
+    expect(file).to respond_to(:datetime_original)
+    expect(file).to respond_to(:datetime_uploaded)
+    expect(file).to respond_to(:datetime_stored)
+    expect(file).to respond_to(:datetime_removed)
   end
 
   it 'responds to datetime_uploaded' do
-    @file.load
-    expect(@file.datetime_uploaded).to be_kind_of(DateTime)
+    file.load
+    expect(file.datetime_uploaded).to be_kind_of(DateTime)
   end
 
   it 'responds to datetime_stored' do
-    @file.load
-    @file.store
-    expect(@file.datetime_stored).to be_kind_of(DateTime)
+    file.load
+    file.store
+    expect(file.datetime_stored).to be_kind_of(DateTime)
   end
 
   it 'responds to datetime_removed' do
-    @file.load
-    wait_until_ready(@file)
-    @file.delete
-    expect(@file.datetime_removed).to be_kind_of(DateTime)
-    expect(@file.datetime_deleted).to be_kind_of(DateTime)
-    expect(@file.datetime_removed).to eq @file.datetime_deleted
+    file.load
+    wait_until_ready(file)
+    file.delete
+    expect(file.datetime_removed).to be_kind_of(DateTime)
+    expect(file.datetime_deleted).to be_kind_of(DateTime)
+    expect(file.datetime_removed).to eq file.datetime_deleted
   end
 
 
   it 'copies itself' do
     # This can cause "File is not ready yet" error if ran too early
     # In this case we retry it 3 times before giving up
-    result = retry_if(Uploadcare::Error::RequestError::BadRequest){@file.copy}
+    result = retry_if(Uploadcare::Error::RequestError::BadRequest){file.copy}
     expect(result).to be_kind_of(Hash)
     expect(result["type"]).to eq "file"
   end
@@ -118,21 +116,21 @@ describe Uploadcare::Api::File do
   describe '#internal_copy' do
     describe 'integration' do
       it 'creates an internal copy of the file' do
-        response = retry_if(Uploadcare::Error::RequestError::BadRequest){@file.internal_copy}
+        response = retry_if(Uploadcare::Error::RequestError::BadRequest){file.internal_copy}
 
         expect( response['type'] ).to eq 'file'
-        expect( response['result']['uuid'] ).not_to eq @file.uuid
+        expect( response['result']['uuid'] ).not_to eq file.uuid
       end
     end
 
     describe 'params' do
-      let(:url_without_ops){ @api.file(SecureRandom.uuid).cdn_url }
+      let(:url_without_ops){ api.file(SecureRandom.uuid).cdn_url }
       let(:url_with_ops){ url_without_ops + "-/crop/5x5/center/" }
-      let(:file){ @api.file(url_with_ops) }
+      let(:file){ api.file(url_with_ops) }
 
       context 'if no params given' do
         it 'requests server to create an unstored copy with operataions applied' do
-          expect(@api).to receive(:post)
+          expect(api).to receive(:post)
             .with('/files/', source: url_with_ops)
 
           file.internal_copy
@@ -141,7 +139,7 @@ describe Uploadcare::Api::File do
 
       context 'if strip_operations: true given' do
         it 'passes url without operations as a source for a copy' do
-          expect(@api).to receive(:post)
+          expect(api).to receive(:post)
             .with('/files/', source: url_without_ops)
 
           file.internal_copy(strip_operations: true)
@@ -150,7 +148,7 @@ describe Uploadcare::Api::File do
 
       context 'if store: true given' do
         it 'requests server to create a stored copy' do
-          expect(@api).to receive(:post)
+          expect(api).to receive(:post)
             .with('/files/', source: url_with_ops, store: true)
 
           file.internal_copy(store: true)
@@ -166,7 +164,7 @@ describe Uploadcare::Api::File do
     describe 'integration', :payed_feature do
       it 'creates an external copy of the file' do
         response = retry_if(Uploadcare::Error::RequestError::BadRequest) do
-                     @file.external_copy(target)
+                     file.external_copy(target)
                    end
 
         expect( response['type'] ).to eq 'url'
@@ -175,13 +173,13 @@ describe Uploadcare::Api::File do
     end
 
     describe 'params' do
-      let(:url_without_ops){ @api.file(SecureRandom.uuid).cdn_url }
+      let(:url_without_ops){ api.file(SecureRandom.uuid).cdn_url }
       let(:url_with_ops){ url_without_ops + "-/resize/50x50/" }
-      let(:file){ @api.file(url_with_ops) }
+      let(:file){ api.file(url_with_ops) }
 
       context 'if only target is given' do
         it 'requests server to create a private copy with default name and with operataions applied' do
-          expect(@api).to receive(:post)
+          expect(api).to receive(:post)
             .with('/files/', source: url_with_ops, target: target)
 
           file.external_copy(target)
@@ -196,7 +194,7 @@ describe Uploadcare::Api::File do
 
       context 'if strip_operations: true given' do
         it 'passes url without operations as a source for a copy' do
-          expect(@api).to receive(:post)
+          expect(api).to receive(:post)
             .with('/files/', source: url_without_ops, target: target)
 
           file.external_copy(target, strip_operations: true)
@@ -205,7 +203,7 @@ describe Uploadcare::Api::File do
 
       context 'if :make_public given' do
         it 'requests server to create a copy with correspondent permissions' do
-          expect(@api).to receive(:post)
+          expect(api).to receive(:post)
             .with('/files/', source: url_with_ops, target: target, make_public: false)
 
           file.external_copy(target, make_public: false)
@@ -214,7 +212,7 @@ describe Uploadcare::Api::File do
 
       context 'if :pattern given' do
         it 'requests server to apply given pattern to name of a copy' do
-          expect(@api).to receive(:post)
+          expect(api).to receive(:post)
             .with('/files/', source: url_with_ops, target: target, pattern: 'test')
 
           file.external_copy(target, pattern: 'test')


### PR DESCRIPTION
### 1 -  Remove old `should` syntax from _file_spec_
** Similar to what had already been done in #42 with _parser_spec_

**Before:**
![should01](https://user-images.githubusercontent.com/8002618/31051459-63b3dbb6-a63f-11e7-8f75-0f258e76715d.png)

**After:**
![should02](https://user-images.githubusercontent.com/8002618/31051474-bc3cb3b6-a63f-11e7-81ac-50f1030fdba1.png)

### 2 - Replace instance variables defined in `before` block with `let`s
Usage of instance variable is an anti-pattern. Usage of `lets` are more efficient.
Ref: http://www.betterspecs.org/#let

**Before:**
![instance-variables](https://user-images.githubusercontent.com/8002618/31051489-142916e6-a640-11e7-993a-ac6af99733c2.png)

**After:**
![instance-variable02](https://user-images.githubusercontent.com/8002618/31051488-142656fe-a640-11e7-822d-676a99b57219.png)

