### PR TITLE
Specify which errors must be raised in specs

### DIFF
--- a/spec/resources/file_spec.rb
+++ b/spec/resources/file_spec.rb
@@ -12,7 +12,7 @@ describe Uploadcare::Api::File do
   end
 
   it 'is not initialized without correct UUID given' do
-    expect {Uploadcare::Api::File.new(api, "not-uuid")}.to raise_error
+    expect {Uploadcare::Api::File.new(api, "not-uuid")}.to raise_error NoMethodError
   end
 
   it 'has a valid url' do

--- a/spec/resources/group_spec.rb
+++ b/spec/resources/group_spec.rb
@@ -96,6 +96,6 @@ describe Uploadcare::Api::Group do
 
   it 'should raise an error if index is greater than files count in group' do
     group = @api.create_group @files
-    expect {group.file_cdn_url(5)}.to raise_error
+    expect {group.file_cdn_url(5)}.to raise_error ArgumentError
   end
 end


### PR DESCRIPTION
When testing errors raising, we must specify expected error name in order to prevent a potential false positive (since specs could raise a different error and then pass for an unexpected reason).

RSpec was launching a warning due to this.
These changes remove the warning.

**Before:**
![raise_error_warning01](https://user-images.githubusercontent.com/8002618/31310440-c4f3d69a-ab6e-11e7-8e63-f98273652423.png)

**After:**
![raise_error_warning02](https://user-images.githubusercontent.com/8002618/31310442-ca72c66c-ab6e-11e7-9c8b-076371a743ea.png)