### PR TITLE
update User-Agent header format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ Gemfile.lock
 
 *.DS_Store
 *.gem
+coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2.0.1, FIXME
+
+- `User-Agent` header format updated to conform the format common for all Uploadcare libraries.
+
 ### 2.0.0, 26.09.2017
 
 - There are **breaking** changes in this release, please read [upgrade notes](UPGRADE_NOTES.md#v1---v2)

--- a/lib/uploadcare.rb
+++ b/lib/uploadcare.rb
@@ -18,6 +18,7 @@ module Uploadcare
     auth_scheme: :secure,
   }
 
+  warn '[DEPRECATION] `Uploadcare::USER_AGENT` constant is deprecated and will be removed in version 3.0'
   USER_AGENT = "uploadcare-ruby/#{Gem.ruby_version}/#{Uploadcare::VERSION}"
 
   def self.default_settings
@@ -25,7 +26,7 @@ module Uploadcare
   end
 
   def self.user_agent(options={})
-    return options[:user_agent].to_s if options[:user_agent]
-    [USER_AGENT, options[:public_key]].join('/')
+    warn '[DEPRECATION] `Uploadcare::user_agent` method is deprecated and will be removed in version 3.0'
+    UserAgent.new.call(options)
   end
 end

--- a/lib/uploadcare/rest/connections/api_connection.rb
+++ b/lib/uploadcare/rest/connections/api_connection.rb
@@ -10,7 +10,7 @@ module Uploadcare
           auth_strategy = Auth.strategy(options)
 
           frd.headers['Accept'] = "application/vnd.uploadcare-v#{options[:api_version]}+json"
-          frd.headers['User-Agent'] = Uploadcare::user_agent(options)
+          frd.headers['User-Agent'] = UserAgent.new.call(options)
 
           # order of middleware matters!
 
@@ -48,7 +48,6 @@ module Uploadcare
           yield(request) if block_given?
         }
       end
-
     end
   end
 end

--- a/lib/uploadcare/rest/connections/upload_connection.rb
+++ b/lib/uploadcare/rest/connections/upload_connection.rb
@@ -9,7 +9,7 @@ module Uploadcare
         super ssl: { ca_path: ca_path }, url: options[:upload_url_base] do |frd|
           frd.request :multipart
           frd.request :url_encoded
-          frd.headers['User-Agent'] = Uploadcare::user_agent(options)
+          frd.headers['User-Agent'] = UserAgent.new.call(options)
 
           frd.response :uploadcare_raise_error
           frd.response :uploadcare_parse_json

--- a/lib/uploadcare/utils/user_agent.rb
+++ b/lib/uploadcare/utils/user_agent.rb
@@ -1,0 +1,35 @@
+module Uploadcare
+  # Determines User-Agent string either taking it from settings or building
+  # in accordance with common Uploadcare format
+  #
+  class UserAgent
+    # @param options [Hash]
+    # @option options [String] :user_agent (nil)
+    # @option options [String] :public_key (nil)
+    # @option options [String] :user_agent_extension (nil)
+    # @return [String]
+    #
+    def call(options)
+      return options[:user_agent].to_s if options[:user_agent]
+      user_agent_string(options)
+    end
+
+    private
+
+    def user_agent_string(options)
+      format(
+        '%<library_string>s/%<public_key>s (%<environment_string>s)',
+        library_string: "UploadcareRuby/#{Uploadcare::VERSION}",
+        public_key: options.fetch(:public_key, nil),
+        environment_string: environment_string(options)
+      )
+    end
+
+    def environment_string(options)
+      [
+        "Ruby/#{Gem.ruby_version};",
+        options.fetch(:user_agent_extension, nil)
+      ].compact.join(' ')
+    end
+  end
+end

--- a/spec/rest/api_connection_spec.rb
+++ b/spec/rest/api_connection_spec.rb
@@ -19,7 +19,7 @@ describe Uploadcare::Connections::ApiConnection do
     end
 
     it 'includes correct User-Agent header' do
-      expected = Uploadcare::user_agent(settings)
+      expected = Uploadcare::UserAgent.new.call(settings)
       expect(subject['User-Agent']).to eq expected
     end
   end

--- a/spec/uploadcare_spec.rb
+++ b/spec/uploadcare_spec.rb
@@ -1,20 +1,16 @@
 require 'spec_helper'
 
 describe Uploadcare do
-
   describe '::user_agent' do
-    context "if :user_agent is specified in method's options" do
-      it "returns it's stringified version" do
-        expect( Uploadcare.user_agent(user_agent: 123) ).to eq '123'
-      end
-    end
+    subject(:user_agent) { described_class.user_agent(options) }
+    let(:options) { {user_agent: 'user/agent'} }
+    let(:user_agent_builder) { instance_double('Uploadcare::UserAgent') }
 
-    context "if user_agent is not specified in method's options" do
-      it 'builds user-agent from ruby version, gem version and public key' do
-        expected = /#{Gem.ruby_version}\/#{described_class::VERSION}\/test/
-        expect( Uploadcare.user_agent(public_key: 'test') ).to match(expected)
-      end
+    it 'returns user agent string' do
+      allow(Uploadcare::UserAgent).to receive(:new) { user_agent_builder }
+      expect(user_agent_builder).to receive(:call).with(options) { 'user/agent' }
+
+      expect(user_agent).to eq('user/agent')
     end
   end
-
 end

--- a/spec/utils/user_agent_spec.rb
+++ b/spec/utils/user_agent_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+describe Uploadcare::UserAgent do
+  subject(:user_agent) { described_class.new.call(options) }
+
+  before do
+    stub_const('Uploadcare::VERSION', '123')
+    allow(Gem).to receive(:ruby_version) { '456' }
+  end
+
+  context 'when user_agent option is set' do
+    let(:options) do
+      { user_agent: 'predefined user agent' }
+    end
+
+    it { is_expected.to eq('predefined user agent') }
+  end
+
+  context 'when user_agent_extension option is set' do
+    let(:options) do
+      { public_key: 'pubkey', user_agent_extension: 'ext' }
+    end
+
+    it { is_expected.to eq('UploadcareRuby/123/pubkey (Ruby/456; ext)') }
+  end
+
+  context 'when user_agent_extension option is not set' do
+    let(:options) do
+      { public_key: 'pubkey' }
+    end
+
+    it { is_expected.to eq('UploadcareRuby/123/pubkey (Ruby/456;)') }
+  end
+end


### PR DESCRIPTION
I believe nobody is using `Uploadcare::USER_AGENT` constant and `Uploadcare::user_agent` method, so I've deprecated them. 

I also think that I should backport this changes to uploadcare-ruby 1.x (updating patch version) so that uploadcare-rails 1.x users could get this update