### PR TITLE
Let uploadcare work with tempfiles

### DIFF
--- a/lib/uploadcare/api/uploading_api.rb
+++ b/lib/uploadcare/api/uploading_api.rb
@@ -5,7 +5,7 @@ module Uploadcare
     # intelegent guess for file or URL uploading
     def upload(object, options = {})
       case object
-      when File then upload_file(object, options)
+      when File, Tempfile then upload_file(object, options)
       when Array then upload_files(object, options)
       # if object is a string, try to upload it as an URL
       when String then upload_url(object, options)

--- a/lib/uploadcare/api/uploading_api/upload_params.rb
+++ b/lib/uploadcare/api/uploading_api/upload_params.rb
@@ -56,7 +56,7 @@ module Uploadcare
       end
 
       def build_upload_io(file)
-        unless file.is_a?(File)
+        unless file.is_a?(File) || file.is_a?(Tempfile)
           raise ArgumentError, "expected File object, #{file} given"
         end
 


### PR DESCRIPTION
This is necessary for using uploadcare on platforms like Heroku that do not allow creation of real files. Plus most web frameworks return uploaded files as tempfiles and there's no easy way to transiently convert them to regular files.