### PR TITLE
Allow to upload `Tempfile`s and files without a mime type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based now on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+- Allow to upload files from a `Tempfile` object
+- Allow to upload files when mime-type can't be determined
+
 ## [2.1.2] - 2018-06-11
 
 ### Fixed

--- a/lib/uploadcare/api/uploading_api.rb
+++ b/lib/uploadcare/api/uploading_api.rb
@@ -4,14 +4,11 @@ module Uploadcare
   module UploadingApi
     # intelegent guess for file or URL uploading
     def upload(object, options = {})
-      case object
-      when File then upload_file(object, options)
-      when Array then upload_files(object, options)
-      # if object is a string, try to upload it as an URL
-      when String then upload_url(object, options)
+      if file?(object)           then upload_file(object, options)
+      elsif object.is_a?(Array)  then upload_files(object, options)
+      elsif object.is_a?(String) then upload_url(object, options)
       else
-        raise ArgumentError, "Expected `object` to be an Uploadcare::Api::File, "\
-          "an Array or a valid URL string, received: `#{object}`"
+        raise ArgumentError, "Expected input to be a file/Array/URL, given: `#{object}`"
       end
     end
 
@@ -66,6 +63,11 @@ module Uploadcare
 
     def upload_params(request_options)
       UploadParams.new(@options, request_options)
+    end
+
+    def file?(object)
+      # will also be true for ActionDispatch::Http::UploadedFile
+      object.respond_to?(:path) && File.exist?(object.path)
     end
   end
 end

--- a/lib/uploadcare/api/uploading_api/upload_params.rb
+++ b/lib/uploadcare/api/uploading_api/upload_params.rb
@@ -56,7 +56,7 @@ module Uploadcare
       end
 
       def build_upload_io(file)
-        unless file.is_a?(File)
+        unless file.respond_to?(:path) && File.exist?(file.path)
           raise ArgumentError, "expected File object, #{file} given"
         end
 
@@ -65,7 +65,7 @@ module Uploadcare
 
       def extract_mime_type file
         types = MIME::Types.of(file.path)
-        types[0].content_type
+        types.any? ? types.first.content_type : nil
       end
     end
   end

--- a/spec/api/uploading_api_spec.rb
+++ b/spec/api/uploading_api_spec.rb
@@ -25,21 +25,36 @@ describe Uploadcare::Api do
   context 'when uploading single object' do
     subject(:uploaded) { api.upload(object, upload_options) }
 
-    context 'when uploading a file' do
-      let(:object) { FILE1 }
-
+    shared_examples 'a successfull upload' do
       it { is_expected.to be_a(Uploadcare::Api::File) }
       it { is_expected.to have_attributes(uuid: match(UUID_REGEX)) }
       include_examples 'respects :store option'
     end
 
+    context 'when uploading a file' do
+      let(:object) { FILE1 }
+      it_behaves_like 'a successfull upload'
+    end
+
+    context 'when uploading a Tempfile' do
+      let(:object) do
+        Tempfile.new(['test', '.png']).tap { |f| f.write(FILE1.read) }
+      end
+
+      it_behaves_like 'a successfull upload'
+    end
+
+    context 'when mime-type could not be determined' do
+      let(:object) { Tempfile.new('test').tap { |f| f.write(FILE1.read) } }
+
+      it_behaves_like 'a successfull upload'
+    end
+
     context 'when uploading from url' do
       let(:object) { IMAGE_URL }
 
-      it { is_expected.to be_a(Uploadcare::Api::File) }
-      it { is_expected.to have_attributes(uuid: match(UUID_REGEX)) }
+      it_behaves_like 'a successfull upload'
       it { expect { api.upload('invalid.url.') }.to raise_error(ArgumentError) }
-      include_examples 'respects :store option'
     end
   end
 


### PR DESCRIPTION
Two issues are being fixed here:

1. Client didn't support passing `Tempfile` objects to `Uploadcare::Api#upload` method (#56). It'll be also possible to pass `ActionDispatch::Http::UploadedFile` objects (which is the class for file params in Rails) though the class itself isn't referenced directly in this PR
2. Client didn't support uploading of files with unknown mime-types. Now it is possible.