### PR TITLE
Add SecureSignature generation for signed uploads

### DIFF
--- a/lib/uploadcare.rb
+++ b/lib/uploadcare.rb
@@ -1,6 +1,8 @@
 require 'faraday'
 require 'json'
 require 'ostruct'
+require 'active_support'
+require 'digest'
 
 require_relative 'uploadcare/api'
 require_relative 'uploadcare/version'

--- a/lib/uploadcare/utils/secure_signature.rb
+++ b/lib/uploadcare/utils/secure_signature.rb
@@ -1,0 +1,18 @@
+module Uploadcare
+  # Generates signatures in the format required for signed uploads
+
+  class SecureSignature
+    def initialize(api_secret_key, expire)
+      @secret = api_secret_key
+      @expire = expire
+    end
+
+    def generate
+      time = (Time.now + @expire).to_i
+      {
+        signature: nil,
+        expire: time,
+      }
+    end
+  end
+end

--- a/spec/utils/secure_signature_spec.rb
+++ b/spec/utils/secure_signature_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe Uploadcare::SecureSignature do
+  subject(:secure_signature) { described_class.new.call(options) }
+
+  context 'when valid arguments are present'
+    let(:options) do
+      {
+        api_secret_key: 'my_super_secret_key',
+        expire: '1231231',
+      }
+    end
+
+    context 'generate' do
+      it 'should generate a valid signature' do
+        expect(true).to eq(false)
+        expect(secure_signature.generate.class).to eq(Hash)
+        expect(secure_signature.generate.signature).to_not eq(nil)
+        expect(secure_signature.generate.expire).to_not eq(nil)
+      end
+    end
+
+end

--- a/uploadcare-ruby.gemspec
+++ b/uploadcare-ruby.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'faraday_middleware', '~> 0.9'
   gem.add_runtime_dependency 'multipart-post'
   gem.add_runtime_dependency 'mime-types'
+  gem.add_runtime_dependency 'activesupport'
 
   gem.add_development_dependency 'rspec', '~> 3.6'
   gem.add_development_dependency 'rake'


### PR DESCRIPTION
I suspect some way of having this library generate signatures in the format required for signed uploads might be a good idea (maybe a ruby example in documentation might be good enough).

I'm sure there are a lot of things wrong on this PR (not sure if tests are even running & adding activesupport) and I'm new to Uploadcare so feel free to throw this away if you think it's needless.

 👍 