### PR TITLE
Bump faraday versions

### DIFF
--- a/uploadcare-ruby.gemspec
+++ b/uploadcare-ruby.gemspec
@@ -26,8 +26,8 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']
   gem.version       = Uploadcare::VERSION
-  gem.add_runtime_dependency 'faraday', '~> 0.8'
-  gem.add_runtime_dependency 'faraday_middleware', '~> 0.9'
+  gem.add_runtime_dependency 'faraday', '>= 0.9'
+  gem.add_runtime_dependency 'faraday_middleware', '>= 0.9'
   gem.add_runtime_dependency 'multipart-post'
   gem.add_runtime_dependency 'mime-types'
 


### PR DESCRIPTION
## Description

The current Faraday dependency is extremely old (8 years ago) and very restrictive.

I've relaxed the version requirements and ran the tests without issues.

Version 3 is still in development and unfortunately forcing anyone that uses the gem to downgrade Faraday to 0.9 is not a great solution. Because of that I believe we can relax those dependencies without issues.

## Changelog Stub

- Relaxed `faraday` and `faraday-middleware` dependency versions

## Checklist

- [ ] Tests (if applicable)
- [ ] Documentation (if applicable)
- [x] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))
