### PR TITLE
Fix File, Webhook client request bodies. Add missing require 'api_struct'

### DIFF
--- a/lib/uploadcare/client/file_list_client.rb
+++ b/lib/uploadcare/client/file_list_client.rb
@@ -25,7 +25,7 @@ module Uploadcare
       # uuids: Array
       def batch_store(uuids)
         body = uuids.to_json
-        put(uri: '/files/storage/', body: body)
+        put(uri: '/files/storage/', content: body)
       end
 
       alias request_delete delete
@@ -35,7 +35,7 @@ module Uploadcare
       # uuids: Array
       def batch_delete(uuids)
         body = uuids.to_json
-        request_delete(uri: '/files/storage/', body: body)
+        request_delete(uri: '/files/storage/', content: body)
       end
 
       alias store_files batch_store

--- a/lib/uploadcare/client/multipart_upload/chunks_client.rb
+++ b/lib/uploadcare/client/multipart_upload/chunks_client.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'parallel'
+require 'api_struct'
 
 module Uploadcare
   module Client

--- a/lib/uploadcare/client/rest_client.rb
+++ b/lib/uploadcare/client/rest_client.rb
@@ -4,6 +4,7 @@ require_relative 'rest_client'
 require 'uploadcare/concern/error_handler'
 require 'uploadcare/concern/throttle_handler'
 require 'param/authentication_header'
+require 'api_struct'
 
 module Uploadcare
   module Client

--- a/lib/uploadcare/client/upload_client.rb
+++ b/lib/uploadcare/client/upload_client.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'api_struct'
 require 'param/user_agent'
 require 'uploadcare/concern/error_handler'
 require 'uploadcare/concern/throttle_handler'

--- a/lib/uploadcare/client/webhook_client.rb
+++ b/lib/uploadcare/client/webhook_client.rb
@@ -29,7 +29,7 @@ module Uploadcare
 
       # Updates webhook
       # @see https://uploadcare.com/docs/api_reference/rest/webhooks/#subscribe-update
-      def update(id, **options)
+      def update(id, options = {})
         body = options.to_json
         post(uri: "/webhooks/#{id}/", content: body)
       end

--- a/lib/uploadcare/client/webhook_client.rb
+++ b/lib/uploadcare/client/webhook_client.rb
@@ -22,8 +22,8 @@ module Uploadcare
 
       # Permanently deletes subscription
       # @see https://uploadcare.com/docs/api_reference/rest/webhooks/#unsubscribe
-      def delete(name)
-        body = { 'name': name }.to_json
+      def delete(target_url)
+        body = { 'target_url': target_url }.to_json
         post(uri: '/webhooks/unsubscribe/', content: body)
       end
 

--- a/lib/uploadcare/entity/file_list.rb
+++ b/lib/uploadcare/entity/file_list.rb
@@ -2,6 +2,7 @@
 
 require 'uploadcare/entity/file'
 require 'uploadcare/entity/decorator/paginator'
+require 'api_struct'
 
 module Uploadcare
   module Entity


### PR DESCRIPTION
## Description

**1. Fix request params: replace key `:body` with `:content` because the `request` is expecting `:content`, not `:body`** in
 - Uploadcare::Client::FileListClient#batch_store
 - Uploadcare::Client::FileListClient#batch_delete

**2. Fix body parameter:**
 - Uploadcare::Client::WebhookClient#delete (`name` -> `target_url`)

**3. Add `require 'api_struct'` where used, because error the `UnitializedConstant` error is raised in some cases (in Rails app)**

**4. Edit  the `options` arg for Uploadcare::Client::WebhookClient#update, so this method can be used with ruby 3.0.0**
## Checklist

- [ ] Tests (if applicable)
- [ ] Documentation (if applicable)
- [ ] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))
