### PR TITLE
ID-1: Fix error handler parsed error

### DIFF
--- a/lib/uploadcare/concern/error_handler.rb
+++ b/lib/uploadcare/concern/error_handler.rb
@@ -14,9 +14,9 @@ module Uploadcare
       def failure(response)
         catch_upload_errors(response)
         parsed_response = JSON.parse(response.body.to_s)
-        raise RequestError, parsed_response['detail']
+        raise RequestError, parsed_response['detail'] || parsed_response.map { |k, v| "#{k}: #{v}" }.join('; ')
       rescue JSON::ParserError
-        raise RequestError, response.status
+        raise RequestError, response.body.to_s
       end
 
       # Extension of ApiStruct's wrap method


### PR DESCRIPTION
## Description

### [Documents conversion](https://uploadcare-evrone.atlassian.net/browse/UC-1)

- Fix error handler for a case when no `detail` key in error message but the message is present.

## Checklist

- [ ] Tests (if applicable)
- [ ] Documentation (if applicable)
- [ ] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))
