### PR TITLE
Fix dry-configurable warning about deprecated way to set defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.2.1 — 2021-12-07
+
+- Fix dry-configurable warning about deprecated way to set defaults.
+
 ## 3.2.0 — 2021-11-16
 
 - Added option `signing_secret` to the `Uploadcare::Webhook`

--- a/lib/uploadcare.rb
+++ b/lib/uploadcare.rb
@@ -28,18 +28,18 @@ require 'api/api'
 # @see https://uploadcare.com/docs/api_reference
 module Uploadcare
   extend Dry::Configurable
-  setting :public_key, ENV.fetch('UPLOADCARE_PUBLIC_KEY')
-  setting :secret_key, ENV.fetch('UPLOADCARE_SECRET_KEY')
-  setting :auth_type, 'Uploadcare'
-  setting :multipart_size_threshold, 100 * 1024 * 1024
-  setting :rest_api_root, 'https://api.uploadcare.com'
-  setting :upload_api_root, 'https://upload.uploadcare.com'
-  setting :max_request_tries, 100
-  setting :base_request_sleep, 1 # seconds
-  setting :max_request_sleep, 60.0 # seconds
-  setting :sign_uploads, false
-  setting :upload_signature_lifetime, 30 * 60 # seconds
-  setting :max_throttle_attempts, 5
-  setting :upload_threads, 2 # used for multiupload only ATM
-  setting :framework_data, ''
+  setting :public_key, default: ENV.fetch('UPLOADCARE_PUBLIC_KEY')
+  setting :secret_key, default: ENV.fetch('UPLOADCARE_SECRET_KEY')
+  setting :auth_type, default: 'Uploadcare'
+  setting :multipart_size_threshold, default: 100 * 1024 * 1024
+  setting :rest_api_root, default: 'https://api.uploadcare.com'
+  setting :upload_api_root, default: 'https://upload.uploadcare.com'
+  setting :max_request_tries, default: 100
+  setting :base_request_sleep, default: 1 # seconds
+  setting :max_request_sleep, default: 60.0 # seconds
+  setting :sign_uploads, default: false
+  setting :upload_signature_lifetime, default: 30 * 60 # seconds
+  setting :max_throttle_attempts, default: 5
+  setting :upload_threads, default: 2 # used for multiupload only ATM
+  setting :framework_data, default: ''
 end

--- a/lib/uploadcare/ruby/version.rb
+++ b/lib/uploadcare/ruby/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Uploadcare
-  VERSION = '3.2.0'
+  VERSION = '3.2.1'
 end

--- a/spec/uploadcare/entity/uploader_spec.rb
+++ b/spec/uploadcare/entity/uploader_spec.rb
@@ -48,7 +48,6 @@ module Uploadcare
             VCR.use_cassette('upload_multipart_upload') do
               # Minimal size for file to be valid for multipart upload is 10 mb
               Uploadcare.config.multipart_size_threshold = 10 * 1024 * 1024
-              expect(some_var).to receive(:to_s).at_least(:once)
               file = subject.multipart_upload(big_file) { some_var.to_s }
               expect(file).to be_kind_of(Uploadcare::Entity::File)
               expect(file.uuid).not_to be_empty


### PR DESCRIPTION
## Description

- Fix dry-configurable warning about deprecated way to set defaults


## Checklist

- [ ] Tests (if applicable)
- [ ] Documentation (if applicable)
- [ ] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))
