### PR TITLE
Fix dry-configurable deprecation warnings

### DIFF
--- a/lib/uploadcare.rb
+++ b/lib/uploadcare.rb
@@ -32,18 +32,18 @@ require 'signed_url_generators/base_generator'
 # @see https://uploadcare.com/docs/api_reference
 module Uploadcare
   extend Dry::Configurable
-  setting :public_key, ENV.fetch('UPLOADCARE_PUBLIC_KEY')
-  setting :secret_key, ENV.fetch('UPLOADCARE_SECRET_KEY')
-  setting :auth_type, 'Uploadcare'
-  setting :multipart_size_threshold, 100 * 1024 * 1024
-  setting :rest_api_root, 'https://api.uploadcare.com'
-  setting :upload_api_root, 'https://upload.uploadcare.com'
-  setting :max_request_tries, 100
-  setting :base_request_sleep, 1 # seconds
-  setting :max_request_sleep, 60.0 # seconds
-  setting :sign_uploads, false
-  setting :upload_signature_lifetime, 30 * 60 # seconds
-  setting :max_throttle_attempts, 5
-  setting :upload_threads, 2 # used for multiupload only ATM
-  setting :framework_data, ''
+  setting :public_key,                default: ENV.fetch('UPLOADCARE_PUBLIC_KEY')
+  setting :secret_key,                default: ENV.fetch('UPLOADCARE_SECRET_KEY')
+  setting :auth_type,                 default: 'Uploadcare'
+  setting :multipart_size_threshold,  default: 100 * 1024 * 1024
+  setting :rest_api_root,             default: 'https://api.uploadcare.com'
+  setting :upload_api_root,           default: 'https://upload.uploadcare.com'
+  setting :max_request_tries,         default: 100
+  setting :base_request_sleep,        default: 1 # seconds
+  setting :max_request_sleep,         default: 60.0 # seconds
+  setting :sign_uploads,              default: false
+  setting :upload_signature_lifetime, default: 30 * 60 # seconds
+  setting :max_throttle_attempts,     default: 5
+  setting :upload_threads,            default: 2 # used for multiupload only ATM
+  setting :framework_data,            default: ''
 end

--- a/lib/uploadcare.rb
+++ b/lib/uploadcare.rb
@@ -39,7 +39,7 @@ module Uploadcare
   # deprecation warnings, we override the dry-configurable's `setting` DSL method.
   def self.setting(name, default:, **options, &block)
     if RUBY_VERSION < '2.6'
-      super name, default = default, &block
+      super name, default, &block
     else
       super
     end

--- a/lib/uploadcare.rb
+++ b/lib/uploadcare.rb
@@ -32,6 +32,19 @@ require 'signed_url_generators/base_generator'
 # @see https://uploadcare.com/docs/api_reference
 module Uploadcare
   extend Dry::Configurable
+
+  # NOTE: The dry-configurable gem has introduced the `default` keyword argument
+  # and deprecated the positional default argument in v0.13.0, which requires
+  # Ruby >= 2.6.0. In order to provide backwards compatibility and not disable
+  # deprecation warnings, we override the dry-configurable's `setting` DSL method.
+  def self.setting(name, default:, **options, &block)
+    if RUBY_VERSION < '2.6'
+      super name, default = default, &block
+    else
+      super
+    end
+  end
+
   setting :public_key,                default: ENV.fetch('UPLOADCARE_PUBLIC_KEY')
   setting :secret_key,                default: ENV.fetch('UPLOADCARE_SECRET_KEY')
   setting :auth_type,                 default: 'Uploadcare'


### PR DESCRIPTION
## Description
With version [0.13.0](https://github.com/dry-rb/dry-configurable/blob/main/CHANGELOG.md#changed-2) of the [dry-configurable](https://github.com/dry-rb/dry-configurable) gem, the default value for a setting provided as a positional argument is deprecated. The `default:` keyword argument should be used instead.

This pull request fixes #97.

## Checklist

- [ ] Tests (if applicable)
- [ ] Documentation (if applicable)
- [ ] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))
