### PR TITLE
Update locations where Dry::Monads structure has changed

### DIFF
--- a/lib/uploadcare/client/conversion/base_conversion_client.rb
+++ b/lib/uploadcare/client/conversion/base_conversion_client.rb
@@ -37,9 +37,9 @@ module Uploadcare
 
           parsed_body = JSON.parse(response_body, symbolize_names: true)
           errors = parsed_body[:error] || parsed_body[:problems]
-          return Dry::Monads::Failure(errors) unless errors.nil? || errors.empty?
+          return Dry::Monads::Result::Failure.call(errors) unless errors.nil? || errors.empty?
 
-          Dry::Monads::Success(parsed_body)
+          Dry::Monads::Result::Success.call(parsed_body)
         end
 
         # Prepares body for convert_many method

--- a/lib/uploadcare/client/rest_group_client.rb
+++ b/lib/uploadcare/client/rest_group_client.rb
@@ -17,7 +17,7 @@ module Uploadcare
           end
         end
 
-        Dry::Monads::Success(nil)
+        Dry::Monads::Result::Success.call(nil)
       end
 
       # Get a file group by its ID.

--- a/lib/uploadcare/client/uploader_client.rb
+++ b/lib/uploadcare/client/uploader_client.rb
@@ -42,7 +42,7 @@ module Uploadcare
         uploaded_response = poll_upload_response(token_response.success[:token])
         return uploaded_response if uploaded_response.success[:status] == 'error'
 
-        Dry::Monads::Success(files: [uploaded_response.success])
+        Dry::Monads::Result::Success.call(files: [uploaded_response.success])
       end
 
       # Check upload status


### PR DESCRIPTION
Success and Failure are now part of `Dry::Monads::Result`.

## Description

When the gem's `Dry::Monads` dependency was upgraded to v1.6, there were a few places that missed upgrading the `Dry::Monads::Success` and `Dry::Monads::Failure` to [their new location](https://github.com/dry-rb/dry-monads/blob/v1.6.0/lib/dry/monads/result.rb#L59), as a class namespaced under `Dry::Monads::Result`

It is interesting that the tests did not fail, we first discovered it when trying to run document conversion using this gem version. Some that are passing but should have failed are [document_conversion_client_spec.rb](https://github.com/uploadcare/uploadcare-ruby/blob/v4.3.5/spec/uploadcare/client/conversion/document_conversion_client_spec.rb).
