### PR TITLE
When polling, raise if an error is returned

### DIFF
--- a/lib/uploadcare.rb
+++ b/lib/uploadcare.rb
@@ -6,6 +6,7 @@ require 'ruby/version'
 # Exceptions
 require 'exception/throttle_error'
 require 'exception/request_error'
+require 'exception/retry_error'
 
 # Entities
 require 'entity/entity'

--- a/lib/uploadcare/exception/request_error.rb
+++ b/lib/uploadcare/exception/request_error.rb
@@ -3,7 +3,6 @@
 module Uploadcare
   module Exception
     # Standard error for invalid API responses
-    class RequestError < StandardError
-    end
+    class RequestError < StandardError; end
   end
 end

--- a/lib/uploadcare/exception/retry_error.rb
+++ b/lib/uploadcare/exception/retry_error.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Uploadcare
+  module Exception
+    # Standard error to raise when needing to retry a request
+    class RetryError < StandardError; end
+  end
+end


### PR DESCRIPTION
Previously, if an error from the API was returned while polling for updates on a file, it would continue polling. I updated the gem so that it raises a `RequestError` if the API returns an error status. If not, it raises a `RetryError`, which is swallowed by the retry gem's `with_retries` block.

## Reproduction Steps
1. Call `Uploadcare::Uploader.upload(file_url)` with a file type that Uploadcare says isn't supported (oddly the `mimetype` on a file I get this message with is `audio/mpeg`, which should be supported).
2. There will be no output from the console while the gem continues to poll `from_url/status/`, which returns an error, such as:
```
{"status":"error","error":"File validation error: Uploading of these file types is not allowed.","error_code":"DownloadFileValidationFailedError"}
```
