### PR TITLE
Fix documentation about original file url on simple file upload. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Uploadcare::Uploader.upload("https://placekitten.com/96/139")
 There are explicit ways to select upload type:
 
 ```ruby
-files = [File.open("1.jpg"), File.open("1.jpg"]
+files = [File.open("1.jpg"), File.open("1.jpg")]
 Uploadcare::Uploader.upload_files(files)
 
 Uploadcare::Uploader.upload_from_url("https://placekitten.com/96/139")

--- a/README.md
+++ b/README.md
@@ -101,8 +101,8 @@ Using Uploadcare is simple, and here are the basics of handling files.
 # => "dc99200d-9bd6-4b43-bfa9-aa7bfaefca40"
 
 # URL for the file, can be used with your website or app right away
-@uc_file.url
-# => "https://ucarecdn.com/dc99200d-9bd6-4b43-bfa9-aa7bfaefca40/"
+@uc_file.original_file_url
+# => "https://ucarecdn.com/dc99200d-9bd6-4b43-bfa9-aa7bfaefca40/your-file.png"
 ```
 
 Your might then want to store or delete the uploaded file. Storing files could

--- a/lib/uploadcare.rb
+++ b/lib/uploadcare.rb
@@ -39,7 +39,7 @@ module Uploadcare
   # deprecation warnings, we override the dry-configurable's `setting` DSL method.
   def self.setting(name, default:, **options, &block)
     if RUBY_VERSION < '2.6'
-      super name, default, &block
+      super(name, default, &block)
     else
       super
     end


### PR DESCRIPTION
## Description

Fixes doc issue in https://github.com/uploadcare/uploadcare-ruby/issues/148


## Checklist

- [ ] Tests (if applicable)
- [x] Documentation (if applicable)
- [ ] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))
