### PR TITLE
fix: Start returning proper error message when raising RequestError in poll_upload_response, to hit to users what is going on. Fixes #141

### DIFF
--- a/lib/uploadcare/client/uploader_client.rb
+++ b/lib/uploadcare/client/uploader_client.rb
@@ -77,7 +77,10 @@ module Uploadcare
                      base_sleep_seconds: Uploadcare.config.base_request_sleep,
                      max_sleep_seconds: Uploadcare.config.max_request_sleep) do
           response = get_upload_from_url_status(token)
-          raise RequestError if %w[progress waiting unknown].include?(response.success[:status])
+
+          if %w[progress waiting unknown].include?(response.success[:status])
+            raise RequestError, 'Upload is taking longer than expected. Try increasing the max_request_tries config if you know your file uploads will take more time.' # rubocop:disable Layout/LineLength
+          end
 
           response
         end

--- a/spec/uploadcare/entity/uploader_spec.rb
+++ b/spec/uploadcare/entity/uploader_spec.rb
@@ -53,6 +53,15 @@ module Uploadcare
               expect(upload[0]).to be_kind_of(Uploadcare::Entity::File)
             end
           end
+
+          it 'raises error with information if file upload takes time' do
+            Uploadcare.config.max_request_tries = 1
+            VCR.use_cassette('upload_upload_from_url') do
+              url = 'https://placekitten.com/2250/2250'
+              error_str = 'Upload is taking longer than expected. Try increasing the max_request_tries config if you know your file uploads will take more time.' # rubocop:disable Layout/LineLength
+              expect { subject.upload(url) }.to raise_error(RequestError, error_str)
+            end
+          end
         end
 
         describe 'multipart_upload' do


### PR DESCRIPTION
## Description

fix: Start returning proper error message when raising RequestError in poll_upload_response, to hit to users what is going on. Fixes #141

## Checklist

- [x] Tests (if applicable)
- [ ] Documentation (if applicable)
- [x] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))
