### PR TITLE
Drop support for Ruby < 3x 

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -16,17 +16,17 @@ jobs:
     strategy:
       matrix:
         ruby-version:
-          - 2.7
           - 3.0
           - 3.1
           - 3.2
+          - 3.3
 
     steps:
     - uses: actions/checkout@v3
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        bundler: 2.4
+        bundler: latest
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true
     - name: Run tests
@@ -41,8 +41,7 @@ jobs:
     strategy:
       matrix:
         ruby-version:
-          - 2.7
-          - 3.2
+          - 3.3
     steps:
     - uses: actions/checkout@v3
     - name: Set up Ruby

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,6 @@
 AllCops:
   NewCops: enable
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.0
 
 Layout/LineLength:
   Max: 120
@@ -13,10 +13,6 @@ Style/HashTransformKeys:
     - 'lib/uploadcare/entity/decorator/paginator.rb'
     - 'lib/uploadcare/client/conversion/video_conversion_client.rb'
     - 'lib/uploadcare/entity/file.rb'
-
-Gemspec/RequiredRubyVersion:
-  Exclude:
-    - 'uploadcare-ruby.gemspec'
 
 Metrics/BlockLength:
   Exclude:

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,6 @@ gem 'byebug'
 gem 'rake'
 gem 'rspec'
 gem 'rubocop'
-gem 'rubocop-rspec'
 gem 'vcr'
 gem 'webmock'
 

--- a/Gemfile
+++ b/Gemfile
@@ -2,12 +2,13 @@
 
 source 'https://rubygems.org'
 
-gem 'byebug', '~> 11.1'
-gem 'rake', '~> 13.0'
-gem 'rspec', '~> 3.0'
-gem 'rubocop', '~> 1.48'
-gem 'vcr', '~> 6.1'
-gem 'webmock', '~> 3.18'
+gem 'byebug'
+gem 'rake'
+gem 'rspec'
+gem 'rubocop'
+gem 'rubocop-rspec'
+gem 'vcr'
+gem 'webmock'
 
 # Specify your gem's dependencies in uploadcare-ruby.gemspec
 gemspec

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ wrapping Upload and REST APIs.
 * [Useful links](#useful-links)
 
 ## Requirements
-* ruby 2.7+
+* ruby 3.0+
 
 ## Compatibility
 

--- a/lib/uploadcare.rb
+++ b/lib/uploadcare.rb
@@ -33,18 +33,6 @@ require 'signed_url_generators/base_generator'
 module Uploadcare
   extend Dry::Configurable
 
-  # NOTE: The dry-configurable gem has introduced the `default` keyword argument
-  # and deprecated the positional default argument in v0.13.0, which requires
-  # Ruby >= 2.6.0. In order to provide backwards compatibility and not disable
-  # deprecation warnings, we override the dry-configurable's `setting` DSL method.
-  def self.setting(name, default:, **options, &block)
-    if RUBY_VERSION < '2.6'
-      super(name, default, &block)
-    else
-      super
-    end
-  end
-
   setting :public_key,                default: ENV.fetch('UPLOADCARE_PUBLIC_KEY', '')
   setting :secret_key,                default: ENV.fetch('UPLOADCARE_SECRET_KEY', '')
   setting :auth_type,                 default: 'Uploadcare'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,7 +6,7 @@ require 'api_struct'
 require 'byebug'
 require 'webmock/rspec'
 require 'uploadcare'
-Dir[File.expand_path(File.join(File.dirname(__FILE__), 'support', '**', '*.rb'))].sort.each { |f| require f }
+Dir[File.expand_path(File.join(File.dirname(__FILE__), 'support', '**', '*.rb'))].each { |f| require f }
 
 RSpec.configure do |config|
   include Uploadcare::Exception

--- a/uploadcare-ruby.gemspec
+++ b/uploadcare-ruby.gemspec
@@ -43,6 +43,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib', 'lib/uploadcare', 'lib/uploadcare/rest']
 
+  spec.required_ruby_version = '>= 3.0'
+
   spec.add_dependency 'mimemagic', '~> 0.4'
   spec.add_dependency 'parallel', '~> 1.22'
   spec.add_dependency 'retries', '~> 0.0'


### PR DESCRIPTION
## Description

- Drop support for Ruby < 3x 

Fixes #152

## Checklist

- [ ] Tests (if applicable)
- [ ] Documentation (if applicable)
- [ ] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))
