### PR TITLE
Add deprecation warning on usage of datetime_stored and clarify README about group delete operation. Closes #131 

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,7 +26,6 @@ Metrics/ModuleLength:
   Exclude:
     - 'spec/**/*'
 
-
 Metrics/MethodLength:
   Max: 20
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,8 @@ AllCops:
 
 Layout/LineLength:
   Max: 120
+  Exclude:
+    - 'spec/**/*'
 
 Lint/IneffectiveAccessModifier:
   Enabled: false
@@ -19,6 +21,11 @@ Metrics/BlockLength:
     - 'bin/'
     - 'spec/**/*'
     - 'uploadcare-ruby.gemspec'
+
+Metrics/ModuleLength:
+  Exclude:
+    - 'spec/**/*'
+
 
 Metrics/MethodLength:
   Max: 20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+* File attribute `datetime_stored` is deprecated and will warn on usage from `File` object properties.
+
 ## 4.4.0 — 2024-03-09
 
-### Breaking 
+### Breaking
 
 * Drop support of unmaintainable Ruby versions < 3.x.
 
@@ -68,7 +73,7 @@ Add support of new ruby versions
 ### Breaking Сhanges
 
 - Drop support of unmaintainable Ruby versions (2.4, 2.5, 2.6).
-- Replace unmaintainable `api_struct` with `uploadcare-api_struct` 
+- Replace unmaintainable `api_struct` with `uploadcare-api_struct`
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -473,6 +473,7 @@ Uploadcare::Group.rest_info(group.id)
 
 # group can be deleted by group ID.
 Uploadcare::Group.delete(group.id)
+# Note: This operation only removes the group object itself. All the files that were part of the group are left as is.
 ```
 
 #### GroupList

--- a/lib/uploadcare.rb
+++ b/lib/uploadcare.rb
@@ -49,5 +49,5 @@ module Uploadcare
   setting :upload_threads,            default: 2 # used for multiupload only ATM
   setting :framework_data,            default: ''
   setting :file_chunk_size,           default: 100
-  setting :logger,                    default: Logger.new(STDOUT)
+  setting :logger,                    default: Logger.new($stdout)
 end

--- a/lib/uploadcare.rb
+++ b/lib/uploadcare.rb
@@ -49,4 +49,5 @@ module Uploadcare
   setting :upload_threads,            default: 2 # used for multiupload only ATM
   setting :framework_data,            default: ''
   setting :file_chunk_size,           default: 100
+  setting :logger,                    default: Logger.new(STDOUT)
 end

--- a/lib/uploadcare/entity/file.rb
+++ b/lib/uploadcare/entity/file.rb
@@ -15,6 +15,11 @@ module Uploadcare
 
       attr_entity(*RESPONSE_PARAMS)
 
+      def datetime_stored
+        Uploadcare.config.logger&.warn "datetime_stored property has be deprecated, and will be removed without a replacement in future."
+        @entity.datetime_stored
+      end
+
       # gets file's uuid - even if it's only initialized with url
       # @returns [String]
       def uuid

--- a/lib/uploadcare/entity/file.rb
+++ b/lib/uploadcare/entity/file.rb
@@ -16,7 +16,7 @@ module Uploadcare
       attr_entity(*RESPONSE_PARAMS)
 
       def datetime_stored
-        Uploadcare.config.logger&.warn "datetime_stored property has be deprecated, and will be removed without a replacement in future."
+        Uploadcare.config.logger&.warn 'datetime_stored property has be deprecated, and will be removed without a replacement in future.' # rubocop:disable Layout/LineLength
         @entity.datetime_stored
       end
 

--- a/spec/uploadcare/entity/addons_spec.rb
+++ b/spec/uploadcare/entity/addons_spec.rb
@@ -2,7 +2,6 @@
 
 require 'spec_helper'
 
-# rubocop:disable Metrics/ModuleLength
 module Uploadcare
   module Entity
     RSpec.describe Addons do
@@ -121,4 +120,3 @@ module Uploadcare
     end
   end
 end
-# rubocop:enable Metrics/ModuleLength

--- a/spec/uploadcare/entity/file_spec.rb
+++ b/spec/uploadcare/entity/file_spec.rb
@@ -61,6 +61,21 @@ module Uploadcare
         end
       end
 
+      describe 'datetime_stored' do
+        it 'returns datetime_stored, with deprecated warning' do
+          VCR.use_cassette('file_info') do
+            url = 'https://ucarecdn.com/8f64f313-e6b1-4731-96c0-6751f1e7a50a'
+            file = File.new(url: url)
+            logger = Uploadcare.config.logger
+            file.load
+            allow(logger).to receive(:warn).with('datetime_stored property has be deprecated, and will be removed without a replacement in future.')
+            datetime_stored = file.datetime_stored
+            expect(logger).to have_received(:warn).with('datetime_stored property has be deprecated, and will be removed without a replacement in future.')
+            expect(datetime_stored).not_to be_nil
+          end
+        end
+      end
+
       describe 'load' do
         it 'performs load request' do
           VCR.use_cassette('file_info') do

--- a/spec/uploadcare/entity/uploader_spec.rb
+++ b/spec/uploadcare/entity/uploader_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe Uploadcare::Entity::Uploader do
         Uploadcare.config.max_request_tries = 1
         VCR.use_cassette('upload_upload_from_url') do
           url = 'https://placekitten.com/2250/2250'
-          error_str = 'Upload is taking longer than expected. Try increasing the max_request_tries config if you know your file uploads will take more time.' # rubocop:disable Layout/LineLength
+          error_str = 'Upload is taking longer than expected. Try increasing the max_request_tries config if you know your file uploads will take more time.'
           expect { subject.upload(url) }.to raise_error(RetryError, error_str)
         end
       end


### PR DESCRIPTION
## Description

- Add default logger to be used in project on the config object. 
- Start using the logger if available to warn about deprecation of datetime_created property on file entity. 
- Override and add datetime_stored method for the same. 
- Clarify in README about the usage of delete operation on group that leaves the files intact.

## Checklist

- [x] Tests (if applicable)
- [x] Documentation (if applicable)
- [x] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))
