### PR TITLE
Add new AuthError class for raising authentication related issues when public/private keys are empty. Closes #158

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Fixed
 
-* Throw error if current public key or secret key are blank when accessing any 
+* Throw `AuthError` if current public key or secret key config are empty when accessing any of the APIs. 
 
 ## 4.4.0 — 2024-03-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 ### Changed
 * File attribute `datetime_stored` is deprecated and will warn on usage from `File` object properties.
 
+## Unreleased
+
+### Fixed
+
+* Throw error if current public key or secret key are blank when accessing any 
+
 ## 4.4.0 — 2024-03-09
 
 ### Breaking

--- a/lib/uploadcare.rb
+++ b/lib/uploadcare.rb
@@ -7,6 +7,7 @@ require 'ruby/version'
 require 'exception/throttle_error'
 require 'exception/request_error'
 require 'exception/retry_error'
+require 'exception/auth_error'
 
 # Entities
 require 'entity/entity'

--- a/lib/uploadcare/exception/auth_error.rb
+++ b/lib/uploadcare/exception/auth_error.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Uploadcare
+  module Exception
+    # Invalid Auth configuration error
+    class AuthError < StandardError; end
+  end
+end

--- a/lib/uploadcare/param/authentication_header.rb
+++ b/lib/uploadcare/param/authentication_header.rb
@@ -11,6 +11,7 @@ module Uploadcare
     class AuthenticationHeader
       # @see https://uploadcare.com/docs/api_reference/rest/requests_auth/#auth-uploadcare
       def self.call(options = {})
+        validate_keys
         case Uploadcare.config.auth_type
         when 'Uploadcare'
           SecureAuthHeader.call(options)
@@ -19,6 +20,13 @@ module Uploadcare
         else
           raise ArgumentError, "Unknown auth_scheme: '#{Uploadcare.config.auth_type}'"
         end
+      end
+
+      private
+
+      def self.validate_keys
+        raise AuthError, "Public Key is blank." if Uploadcare.config.public_key.empty?
+        raise AuthError, "Secret Key is blank." if Uploadcare.config.secret_key.empty?
       end
     end
   end

--- a/lib/uploadcare/param/authentication_header.rb
+++ b/lib/uploadcare/param/authentication_header.rb
@@ -22,11 +22,9 @@ module Uploadcare
         end
       end
 
-      private
-
       def self.validate_keys
-        raise AuthError, "Public Key is blank." if Uploadcare.config.public_key.empty?
-        raise AuthError, "Secret Key is blank." if Uploadcare.config.secret_key.empty?
+        raise AuthError, 'Public Key is blank.' if Uploadcare.config.public_key.empty?
+        raise AuthError, 'Secret Key is blank.' if Uploadcare.config.secret_key.empty?
       end
     end
   end

--- a/lib/uploadcare/param/authentication_header.rb
+++ b/lib/uploadcare/param/authentication_header.rb
@@ -27,9 +27,11 @@ module Uploadcare
         raise AuthError, 'Secret Key is blank.' if is_blank?(Uploadcare.config.secret_key)
       end
 
+      # rubocop:disable Naming/PredicateName
       def self.is_blank?(value)
         value.nil? || value.empty?
       end
+      # rubocop:enable Naming/PredicateName
     end
   end
 end

--- a/lib/uploadcare/param/authentication_header.rb
+++ b/lib/uploadcare/param/authentication_header.rb
@@ -11,7 +11,7 @@ module Uploadcare
     class AuthenticationHeader
       # @see https://uploadcare.com/docs/api_reference/rest/requests_auth/#auth-uploadcare
       def self.call(options = {})
-        validate_keys
+        validate_auth_config
         case Uploadcare.config.auth_type
         when 'Uploadcare'
           SecureAuthHeader.call(options)
@@ -22,9 +22,13 @@ module Uploadcare
         end
       end
 
-      def self.validate_keys
-        raise AuthError, 'Public Key is blank.' if Uploadcare.config.public_key.empty?
-        raise AuthError, 'Secret Key is blank.' if Uploadcare.config.secret_key.empty?
+      def self.validate_auth_config
+        raise AuthError, 'Public Key is blank.' if is_blank?(Uploadcare.config.public_key)
+        raise AuthError, 'Secret Key is blank.' if is_blank?(Uploadcare.config.secret_key)
+      end
+
+      def self.is_blank?(value)
+        value.nil? || value.empty?
       end
     end
   end

--- a/spec/uploadcare/client/file_client_spec.rb
+++ b/spec/uploadcare/client/file_client_spec.rb
@@ -16,6 +16,22 @@ module Uploadcare
           end
         end
 
+        it 'show raise argument error if public_key is blank' do
+          Uploadcare.config.public_key = ''
+          VCR.use_cassette('rest_file_info') do
+            uuid = '2e17f5d1-d423-4de6-8ee5-6773cc4a7fa6'
+            expect { subject.info(uuid) }.to raise_error(AuthError, 'Public Key is blank.')
+          end
+        end
+
+        it 'show raise argument error if secret_key is blank' do
+          Uploadcare.config.secret_key = ''
+          VCR.use_cassette('rest_file_info') do
+            uuid = '2e17f5d1-d423-4de6-8ee5-6773cc4a7fa6'
+            expect { subject.info(uuid) }.to raise_error(AuthError, 'Secret Key is blank.')
+          end
+        end
+
         it 'supports extra params like include' do
           VCR.use_cassette('rest_file_info') do
             uuid = '640fe4b7-7352-42ca-8d87-0e4387957157'

--- a/spec/uploadcare/client/file_client_spec.rb
+++ b/spec/uploadcare/client/file_client_spec.rb
@@ -32,6 +32,14 @@ module Uploadcare
           end
         end
 
+        it 'show raise argument error if secret_key is nil' do
+          Uploadcare.config.secret_key = nil
+          VCR.use_cassette('rest_file_info') do
+            uuid = '2e17f5d1-d423-4de6-8ee5-6773cc4a7fa6'
+            expect { subject.info(uuid) }.to raise_error(AuthError, 'Secret Key is blank.')
+          end
+        end
+
         it 'supports extra params like include' do
           VCR.use_cassette('rest_file_info') do
             uuid = '640fe4b7-7352-42ca-8d87-0e4387957157'

--- a/spec/uploadcare/param/authentication_header_spec.rb
+++ b/spec/uploadcare/param/authentication_header_spec.rb
@@ -18,5 +18,15 @@ module Uploadcare
       Uploadcare.config.auth_type = 'Uploadcare'
       expect(subject.call).to eq('SecureAuth called')
     end
+
+    it 'raise argument error if public_key is blank' do
+      Uploadcare.config.public_key = ''
+      expect { subject.call }.to raise_error(AuthError, 'Public Key is blank.')
+    end
+
+    it 'raise argument error if secret_key is blank' do
+      Uploadcare.config.secret_key = ''
+      expect { subject.call }.to raise_error(AuthError, 'Secret Key is blank.')
+    end
   end
 end


### PR DESCRIPTION
## Description

- Add a new AuthError class for raising authentication-related issues when public/private keys are empty. Closes #158

## Checklist

- [x] Tests (if applicable)
- [x] Documentation (if applicable)
- [ ] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))
