### PR TITLE
[gh-134] Various Signed URLs generation updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 
 * Throw `AuthError` if current public key or secret key config are empty when accessing any of the APIs. 
 
+### Added
+* Added an optional `wildcard` boolean parameter to the `generate_url` method of `AmakaiGenerator`.
+
 ## 4.4.0 — 2024-03-09
 
 ### Breaking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@
 
 ### Fixed
 
-* Throw `AuthError` if current public key or secret key config are empty when accessing any of the APIs. 
+* Throw `AuthError` if current public key or secret key config are empty when accessing any of the APIs.
+* Fixed typo in `AkamaiGenerator` class name from `AmakaiGenerator`.
 
 ### Added
 * Added an optional `wildcard` boolean parameter to the `generate_url` method of `AkamaiGenerator`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 * Throw `AuthError` if current public key or secret key config are empty when accessing any of the APIs. 
 
 ### Added
-* Added an optional `wildcard` boolean parameter to the `generate_url` method of `AmakaiGenerator`.
+* Added an optional `wildcard` boolean parameter to the `generate_url` method of `AkamaiGenerator`.
 
 ## 4.4.0 — 2024-03-09
 

--- a/README.md
+++ b/README.md
@@ -842,7 +842,7 @@ To generate authenticated URL from the library, you should choose `Uploadcare::S
 
 ```ruby
 generator = Uploadcare::SignedUrlGenerators::AkamaiGenerator.new(cdn_host: 'example.com', secret_key: 'secret_key') 
-#Optional parameters: ttl: 300, algorithm: 'sha256'
+# Optional parameters: ttl: 300, algorithm: 'sha256'
 generator.generate_url(uuid, acl = optional)
 
 generator.generate_url("a7d5645e-5cd7-4046-819f-a6a2933bafe3")

--- a/README.md
+++ b/README.md
@@ -826,14 +826,15 @@ More examples and options can be found [here](https://uploadcare.com/docs/transf
 You can use custom domain and CDN provider to deliver files with authenticated URLs (see [original documentation](https://uploadcare.com/docs/security/secure_delivery/)).
 
 To generate authenticated URL from the library, you should choose `Uploadcare::SignedUrlGenerators::AmakaiGenerator` (or create your generator implementation):
+
 ```ruby
-generator = Uploadcare::SignedUrlGenerators::AmakaiGenerator.new(cdn_host: 'example.com', secret_key: 'secret_key'). Optional parameters: ttl: 300, algorithm: 'sha256'
+generator = Uploadcare::SignedUrlGenerators::AkamaiGenerator.new(cdn_host: 'example.com', secret_key: 'secret_key').Optional parameters: ttl : 300, algorithm : 'sha256'
 generator.generate_url(uuid, acl = optional)
 
 generator.generate_url("a7d5645e-5cd7-4046-819f-a6a2933bafe3") ->
-https://example.com/a7d5645e-5cd7-4046-819f-a6a2933bafe3/?token=exp=1649405263~acl=/a7d5645e-5cd7-4046-819f-a6a2933bafe3/~hmac=a989cae5342f17013677f5a0e6577fc5594cc4e238fb4c95eda36634eb47018b
+https: //ex ample.com / a7d5645e - 5 cd7 - 4046 - 819 f - a6a2933bafe3 / ? token = exp = 1649405263 ~acl = /a7d5645e-5cd7-4046-819f-a6a2933bafe3/ ~hmac = a989cae5342f17013677f5a0e6577fc5594cc4e238fb4c95eda36634eb47018b
 generator.generate_url("a7d5645e-5cd7-4046-819f-a6a2933bafe3", '/*/') ->
-https://example.com/a7d5645e-5cd7-4046-819f-a6a2933bafe3/?token=exp=1649405263~acl=/*/~hmac=3ce1152c6af8864b36d4dc721f08ca3cf0b3a20278d7f849e82c6c930d48ccc1
+https: //ex ample.com / a7d5645e - 5 cd7 - 4046 - 819 f - a6a2933bafe3 / ? token = exp = 1649405263 ~acl = /*/ ~hmac = 3 ce1152c6af8864b36d4dc721f08ca3cf0b3a20278d7f849e82c6c930d48ccc1
 ```
 ## Useful links
 

--- a/README.md
+++ b/README.md
@@ -838,7 +838,7 @@ More examples and options can be found [here](https://uploadcare.com/docs/transf
 
 You can use custom domain and CDN provider to deliver files with authenticated URLs (see [original documentation](https://uploadcare.com/docs/security/secure_delivery/)).
 
-To generate authenticated URL from the library, you should choose `Uploadcare::SignedUrlGenerators::AmakaiGenerator` (or create your generator implementation):
+To generate authenticated URL from the library, you should choose `Uploadcare::SignedUrlGenerators::AkamaiGenerator` (or create your generator implementation):
 
 ```ruby
 generator = Uploadcare::SignedUrlGenerators::AkamaiGenerator.new(cdn_host: 'example.com', secret_key: 'secret_key') 

--- a/README.md
+++ b/README.md
@@ -828,13 +828,14 @@ You can use custom domain and CDN provider to deliver files with authenticated U
 To generate authenticated URL from the library, you should choose `Uploadcare::SignedUrlGenerators::AmakaiGenerator` (or create your generator implementation):
 
 ```ruby
-generator = Uploadcare::SignedUrlGenerators::AkamaiGenerator.new(cdn_host: 'example.com', secret_key: 'secret_key').Optional parameters: ttl : 300, algorithm : 'sha256'
+generator = Uploadcare::SignedUrlGenerators::AkamaiGenerator.new(cdn_host: 'example.com', secret_key: 'secret_key') 
+#Optional parameters: ttl: 300, algorithm: 'sha256'
 generator.generate_url(uuid, acl = optional)
 
-generator.generate_url("a7d5645e-5cd7-4046-819f-a6a2933bafe3") ->
-https: //ex ample.com / a7d5645e - 5 cd7 - 4046 - 819 f - a6a2933bafe3 / ? token = exp = 1649405263 ~acl = /a7d5645e-5cd7-4046-819f-a6a2933bafe3/ ~hmac = a989cae5342f17013677f5a0e6577fc5594cc4e238fb4c95eda36634eb47018b
-generator.generate_url("a7d5645e-5cd7-4046-819f-a6a2933bafe3", '/*/') ->
-https: //ex ample.com / a7d5645e - 5 cd7 - 4046 - 819 f - a6a2933bafe3 / ? token = exp = 1649405263 ~acl = /*/ ~hmac = 3 ce1152c6af8864b36d4dc721f08ca3cf0b3a20278d7f849e82c6c930d48ccc1
+generator.generate_url("a7d5645e-5cd7-4046-819f-a6a2933bafe3")
+# https://example.com/a7d5645e-5cd7-4046-819f-a6a2933bafe3/?token=exp=1649405263~acl=/a7d5645e-5cd7-4046-819f-a6a2933bafe3/~hmac=a989cae5342f17013677f5a0e6577fc5594cc4e238fb4c95eda36634eb47018b
+generator.generate_url("a7d5645e-5cd7-4046-819f-a6a2933bafe3", '/*/') 
+# https://example.com/a7d5645e-5cd7-4046-819f-a6a2933bafe3/?token=exp=1649405263~acl=/*/~hmac=3ce1152c6af8864b36d4dc721f08ca3cf0b3a20278d7f849e82c6c930d48ccc1
 ```
 ## Useful links
 

--- a/README.md
+++ b/README.md
@@ -838,7 +838,7 @@ More examples and options can be found [here](https://uploadcare.com/docs/transf
 
 You can use custom domain and CDN provider to deliver files with authenticated URLs (see [original documentation](https://uploadcare.com/docs/security/secure_delivery/)).
 
-To generate authenticated URL from the library, you should choose `Uploadcare::SignedUrlGenerators::AkamaiGenerator` (or create your generator implementation):
+To generate authenticated URL from the library, you should choose `Uploadcare::SignedUrlGenerators::AkamaiGenerator` (or create your own generator implementation):
 
 ```ruby
 generator = Uploadcare::SignedUrlGenerators::AkamaiGenerator.new(cdn_host: 'example.com', secret_key: 'secret_key') 
@@ -847,8 +847,20 @@ generator.generate_url(uuid, acl = optional)
 
 generator.generate_url("a7d5645e-5cd7-4046-819f-a6a2933bafe3")
 # https://example.com/a7d5645e-5cd7-4046-819f-a6a2933bafe3/?token=exp=1649405263~acl=/a7d5645e-5cd7-4046-819f-a6a2933bafe3/~hmac=a989cae5342f17013677f5a0e6577fc5594cc4e238fb4c95eda36634eb47018b
+
+# You can pass in ACL as a second parameter to generate_url. See https://uploadcare.com/docs/security/secure-delivery/#authenticated-urls for supported acl formats
 generator.generate_url("a7d5645e-5cd7-4046-819f-a6a2933bafe3", '/*/') 
 # https://example.com/a7d5645e-5cd7-4046-819f-a6a2933bafe3/?token=exp=1649405263~acl=/*/~hmac=3ce1152c6af8864b36d4dc721f08ca3cf0b3a20278d7f849e82c6c930d48ccc1
+
+# Optionally you can use wildcard: true to generate a wildcard acl token
+generator.generate_url("a7d5645e-5cd7-4046-819f-a6a2933bafe3", wildcard: true)
+# https://example.com/a7d5645e-5cd7-4046-819f-a6a2933bafe3/?token=exp=1714233449~acl=/a7d5645e-5cd7-4046-819f-a6a2933bafe3/*~hmac=a568ee2a85dd90a8a8a1ef35ea0cc0ef0acb84fe81990edd3a06eacf10a52b4e
+ 
+# You can also pass in a custom ttl and algorithm to AkamaiGenerator
+generator = Uploadcare::SignedUrlGenerators::AkamaiGenerator.new(cdn_host: 'example.com', secret_key: 'secret_key', ttl: 10)
+generator.generate_url("a7d5645e-5cd7-4046-819f-a6a2933bafe3")
+# This generates a URL that expires in 10 seconds
+# https://example.com/a7d5645e-5cd7-4046-819f-a6a2933bafe3/?token=exp=1714233277~acl=/a7d5645e-5cd7-4046-819f-a6a2933bafe3/~hmac=f25343104aeced3004d2cc4d49807d8d7c732300b54b154c319da5283a871a71
 ```
 ## Useful links
 

--- a/lib/uploadcare.rb
+++ b/lib/uploadcare.rb
@@ -26,7 +26,7 @@ require 'param/webhook_signature_verifier'
 require 'api/api'
 
 # SignedUrlGenerators
-require 'signed_url_generators/amakai_generator'
+require 'signed_url_generators/akamai_generator'
 require 'signed_url_generators/base_generator'
 
 # Ruby wrapper for Uploadcare API

--- a/lib/uploadcare/entity/file.rb
+++ b/lib/uploadcare/entity/file.rb
@@ -16,7 +16,7 @@ module Uploadcare
       attr_entity(*RESPONSE_PARAMS)
 
       def datetime_stored
-        Uploadcare.config.logger&.warn 'datetime_stored property has be deprecated, and will be removed without a replacement in future.' # rubocop:disable Layout/LineLength
+        Uploadcare.config.logger&.warn 'datetime_stored property has been deprecated, and will be removed without a replacement in future.' # rubocop:disable Layout/LineLength
         @entity.datetime_stored
       end
 

--- a/lib/uploadcare/signed_url_generators/akamai_generator.rb
+++ b/lib/uploadcare/signed_url_generators/akamai_generator.rb
@@ -11,14 +11,14 @@ module Uploadcare
       def generate_url(uuid, acl = uuid, wildcard: false)
         raise ArgumentError, 'Must contain valid UUID' unless valid?(uuid)
 
-        formated_acl = build_acl(uuid, acl, wildcard: wildcard)
+        formatted_acl = build_acl(uuid, acl, wildcard: wildcard)
         expire = build_expire
-        signature = build_signature(expire, formated_acl)
+        signature = build_signature(expire, formatted_acl)
 
         TEMPLATE.gsub('{delimiter}', delimiter)
                 .sub('{cdn_host}', sanitized_string(cdn_host))
                 .sub('{uuid}', sanitized_string(uuid))
-                .sub('{acl}', formated_acl)
+                .sub('{acl}', formatted_acl)
                 .sub('{expiration}', expire)
                 .sub('{token}', signature)
       end
@@ -46,8 +46,9 @@ module Uploadcare
       end
 
       def build_signature(expire, acl)
-        signature = %W[exp=#{expire} acl=#{acl}].join(delimiter)
-        OpenSSL::HMAC.hexdigest(algorithm, secret_key, signature)
+        signature = ["exp=#{expire}", "acl=#{acl}"].join(delimiter)
+        secret_key_bin = Array(secret_key.gsub(/\s/,'')).pack("H*")
+        OpenSSL::HMAC.hexdigest(algorithm, secret_key_bin, signature)
       end
 
       # rubocop:disable Style/SlicingWithRange

--- a/lib/uploadcare/signed_url_generators/akamai_generator.rb
+++ b/lib/uploadcare/signed_url_generators/akamai_generator.rb
@@ -4,20 +4,21 @@ require_relative 'base_generator'
 
 module Uploadcare
   module SignedUrlGenerators
-    class AmakaiGenerator < Uploadcare::SignedUrlGenerators::BaseGenerator
+    class AkamaiGenerator < Uploadcare::SignedUrlGenerators::BaseGenerator
       UUID_REGEX = '[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89aAbB][a-f0-9]{3}-[a-f0-9]{12}'
       TEMPLATE = 'https://{cdn_host}/{uuid}/?token=exp={expiration}{delimiter}acl={acl}{delimiter}hmac={token}'
 
-      def generate_url(uuid, acl = uuid)
+      def generate_url(uuid, acl = uuid, wildcard: false)
         raise ArgumentError, 'Must contain valid UUID' unless valid?(uuid)
 
+        formated_acl = build_acl(uuid, acl, wildcard:)
         expire = build_expire
-        signature = build_signature(expire, acl)
+        signature = build_signature(expire, formated_acl)
 
         TEMPLATE.gsub('{delimiter}', delimiter)
                 .sub('{cdn_host}', sanitized_string(cdn_host))
                 .sub('{uuid}', sanitized_string(uuid))
-                .sub('{acl}', "/#{sanitized_string(acl)}/")
+                .sub('{acl}', formated_acl)
                 .sub('{expiration}', expire)
                 .sub('{token}', signature)
       end
@@ -32,12 +33,20 @@ module Uploadcare
         '~'
       end
 
+      def build_acl(uuid, acl, wildcard: false)
+        if wildcard
+          "/#{sanitized_string(uuid)}/*"
+        else
+          "/#{sanitized_string(acl)}/"
+        end
+      end
+
       def build_expire
         (Time.now.to_i + ttl).to_s
       end
 
       def build_signature(expire, acl)
-        signature = ["exp=#{expire}", "acl=/#{sanitized_string(acl)}/"].join(delimiter)
+        signature = %W[exp=#{expire} acl=#{acl}].join(delimiter)
         OpenSSL::HMAC.hexdigest(algorithm, secret_key, signature)
       end
 

--- a/lib/uploadcare/signed_url_generators/akamai_generator.rb
+++ b/lib/uploadcare/signed_url_generators/akamai_generator.rb
@@ -47,7 +47,7 @@ module Uploadcare
 
       def build_signature(expire, acl)
         signature = ["exp=#{expire}", "acl=#{acl}"].join(delimiter)
-        secret_key_bin = Array(secret_key.gsub(/\s/,'')).pack("H*")
+        secret_key_bin = Array(secret_key.gsub(/\s/, '')).pack('H*')
         OpenSSL::HMAC.hexdigest(algorithm, secret_key_bin, signature)
       end
 

--- a/lib/uploadcare/signed_url_generators/akamai_generator.rb
+++ b/lib/uploadcare/signed_url_generators/akamai_generator.rb
@@ -11,7 +11,7 @@ module Uploadcare
       def generate_url(uuid, acl = uuid, wildcard: false)
         raise ArgumentError, 'Must contain valid UUID' unless valid?(uuid)
 
-        formated_acl = build_acl(uuid, acl, wildcard:)
+        formated_acl = build_acl(uuid, acl, wildcard: wildcard)
         expire = build_expire
         signature = build_signature(expire, formated_acl)
 

--- a/spec/uploadcare/entity/file_spec.rb
+++ b/spec/uploadcare/entity/file_spec.rb
@@ -68,9 +68,9 @@ module Uploadcare
             file = File.new(url: url)
             logger = Uploadcare.config.logger
             file.load
-            allow(logger).to receive(:warn).with('datetime_stored property has be deprecated, and will be removed without a replacement in future.')
+            allow(logger).to receive(:warn).with('datetime_stored property has been deprecated, and will be removed without a replacement in future.')
             datetime_stored = file.datetime_stored
-            expect(logger).to have_received(:warn).with('datetime_stored property has be deprecated, and will be removed without a replacement in future.')
+            expect(logger).to have_received(:warn).with('datetime_stored property has been deprecated, and will be removed without a replacement in future.')
             expect(datetime_stored).not_to be_nil
           end
         end

--- a/spec/uploadcare/signed_url_generators/akamai_generator_spec.rb
+++ b/spec/uploadcare/signed_url_generators/akamai_generator_spec.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'signed_url_generators/amakai_generator'
+require 'signed_url_generators/akamai_generator'
 
 module Uploadcare
-  RSpec.describe SignedUrlGenerators::AmakaiGenerator do
+  RSpec.describe SignedUrlGenerators::AkamaiGenerator do
     subject { described_class.new(cdn_host: 'example.com', secret_key: secret_key) }
 
     let(:default_ttl) { 300 }
@@ -45,6 +45,13 @@ module Uploadcare
       context 'when uuid not valid' do
         it 'returns exception' do
           expect { subject.generate_url(SecureRandom.hex) }.to raise_error ArgumentError
+        end
+      end
+
+      context 'when wildcard is true' do
+        it 'returns correct url' do
+          expected_url = 'https://example.com/a7d5645e-5cd7-4046-819f-a6a2933bafe3/?token=exp=1649343900~acl=/a7d5645e-5cd7-4046-819f-a6a2933bafe3/*~hmac=f0ae3655fb66376a172c29978c0e3db23c1359aec636c7f3395a165520d84d54'
+          expect(subject.generate_url(uuid, nil, wildcard: true)).to eq expected_url
         end
       end
     end

--- a/spec/uploadcare/signed_url_generators/akamai_generator_spec.rb
+++ b/spec/uploadcare/signed_url_generators/akamai_generator_spec.rb
@@ -20,7 +20,7 @@ module Uploadcare
 
       context 'when acl not present' do
         it 'returns correct url' do
-          expected_url = 'https://example.com/a7d5645e-5cd7-4046-819f-a6a2933bafe3/?token=exp=1649343900~acl=/a7d5645e-5cd7-4046-819f-a6a2933bafe3/~hmac=a82d0068adeb2fc5ecf87e7210fe537d234940807725f982dd6c776cbd24df3a'
+          expected_url = 'https://example.com/a7d5645e-5cd7-4046-819f-a6a2933bafe3/?token=exp=1649343900~acl=/a7d5645e-5cd7-4046-819f-a6a2933bafe3/~hmac=d8b4919d595805fd8923258bb647065b7d7201dad8f475d6f5c430e3bffa8122'
           expect(subject.generate_url(uuid)).to eq expected_url
         end
       end
@@ -29,7 +29,7 @@ module Uploadcare
         let(:uuid) { "#{super()}/-/resize/640x/other/transformations/" }
 
         it 'returns correct url' do
-          expected_url = 'https://example.com/a7d5645e-5cd7-4046-819f-a6a2933bafe3/-/resize/640x/other/transformations/?token=exp=1649343900~acl=/a7d5645e-5cd7-4046-819f-a6a2933bafe3/-/resize/640x/other/transformations/~hmac=7517f479d4413225b48b91f51b83c13f26c1e690adc72dff4dcf627e23d7f676'
+          expected_url = 'https://example.com/a7d5645e-5cd7-4046-819f-a6a2933bafe3/-/resize/640x/other/transformations/?token=exp=1649343900~acl=/a7d5645e-5cd7-4046-819f-a6a2933bafe3/-/resize/640x/other/transformations/~hmac=64dd1754c71bf194fcc81d49c413afeb3bbe0e6d703ed4c9b30a8a48c1782f53'
           expect(subject.generate_url(uuid)).to eq expected_url
         end
       end
@@ -37,7 +37,7 @@ module Uploadcare
       context 'when acl present' do
         it 'returns correct url' do
           acl = '/*/'
-          expected_url = 'https://example.com/a7d5645e-5cd7-4046-819f-a6a2933bafe3/?token=exp=1649343900~acl=/*/~hmac=06ab92c7ae863f7d6375d9fd28aa02bd7ca1cab9a10a14653b6cf6ea4f5170b2'
+          expected_url = 'https://example.com/a7d5645e-5cd7-4046-819f-a6a2933bafe3/?token=exp=1649343900~acl=/*/~hmac=984914950bccbfe22f542aa1891300fb2624def1208452335fc72520c934c4c3'
           expect(subject.generate_url(uuid, acl)).to eq expected_url
         end
       end
@@ -50,7 +50,7 @@ module Uploadcare
 
       context 'when wildcard is true' do
         it 'returns correct url' do
-          expected_url = 'https://example.com/a7d5645e-5cd7-4046-819f-a6a2933bafe3/?token=exp=1649343900~acl=/a7d5645e-5cd7-4046-819f-a6a2933bafe3/*~hmac=f0ae3655fb66376a172c29978c0e3db23c1359aec636c7f3395a165520d84d54'
+          expected_url = 'https://example.com/a7d5645e-5cd7-4046-819f-a6a2933bafe3/?token=exp=1649343900~acl=/a7d5645e-5cd7-4046-819f-a6a2933bafe3/*~hmac=6f032220422cdaea5fe0b58f9dcf681269591bb5d1231aa1c4a38741d7cc2fe5'
           expect(subject.generate_url(uuid, nil, wildcard: true)).to eq expected_url
         end
       end


### PR DESCRIPTION
## Description

- Fix Amakai class name typo to Akamai
- Start adding acl capability to signed generators 

## Checklist

- [x] Tests (if applicable)
- [x] Documentation (if applicable)
- [x] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added support for generating wildcard ACL tokens with the new `wildcard` parameter in `AkamaiGenerator`.
	- Introduced `build_acl` method for ACL construction based on `wildcard`.

- **Bug Fixes**
	- Corrected typo in the deprecation warning message for the `datetime_stored` property.

- **Documentation**
	- Updated README to reflect changes in method parameters and class names.
	- Updated deprecation warning documentation in code comments.

- **Refactor**
	- Renamed `AmakaiGenerator` to `AkamaiGenerator` across various files.
	- Updated import statements to reflect the new class name.

- **Tests**
	- Adjusted tests to accommodate new `wildcard` parameter in URL generation.
	- Updated test cases to correct log message assertions related to property deprecation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->