### PR TITLE
Prepare for 4.4.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 * Added `AWS Rekognition Moderation` Add-On.
+* Added an optional `wildcard` boolean parameter to the `generate_url` method of `AkamaiGenerator`.
 
 ### Changed
 * File attribute `datetime_stored` is deprecated and will warn on usage from `File` object properties.
@@ -12,9 +13,6 @@
 
 * Throw `AuthError` if current public key or secret key config are empty when accessing any of the APIs.
 * Fixed typo in `AkamaiGenerator` class name from `AmakaiGenerator`.
-
-### Added
-* Added an optional `wildcard` boolean parameter to the `generate_url` method of `AkamaiGenerator`.
 
 ## 4.4.0 — 2024-03-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 ### Fixed
 
 * Throw `AuthError` if current public key or secret key config are empty when accessing any of the APIs.
-* Fixed typo in `AkamaiGenerator` class name from `AmakaiGenerator`.
+* `AmakaiGenerator` has been renamed to `AkamaiGenerator` to fix typo in class name.
 
 ## 4.4.0 — 2024-03-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,12 @@
 # Changelog
 
-## Unreleased
+## 4.4.1 — 2024-04-27
 
 ### Added
 * Added `AWS Rekognition Moderation` Add-On.
 
 ### Changed
 * File attribute `datetime_stored` is deprecated and will warn on usage from `File` object properties.
-
-## Unreleased
 
 ### Fixed
 

--- a/lib/uploadcare/ruby/version.rb
+++ b/lib/uploadcare/ruby/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Uploadcare
-  VERSION = '4.4.0'
+  VERSION = '4.4.1'
 end


### PR DESCRIPTION
## Description

Many things have been pushed since the last release and other libraries depend on some of these changes.

Changelog-

### Added
* Added `AWS Rekognition Moderation` Add-On.
* Added an optional `wildcard` boolean parameter to the `generate_url` method of `AkamaiGenerator`.

### Changed
* File attribute `datetime_stored` is deprecated and will warn on usage from `File` object properties.

### Fixed

* Throw `AuthError` if current public key or secret key config are empty when accessing any of the APIs.
* `AmakaiGenerator` has been renamed to `AkamaiGenerator` to fix typo in class name.

## Checklist

- [ ] Tests (if applicable)
- [ ] Documentation (if applicable)
- [ ] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added an optional feature to enhance URL generation flexibility.
- **Refactor**
	- Corrected the naming of a key class to improve clarity.
- **Documentation**
	- Updated version number to reflect the latest release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->