### PR TITLE
Add conversion document info API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Added
+* Added `Document Info` API in `DocumentConverter`.
+
 ## 4.4.1 — 2024-04-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,7 @@
 ## Unreleased
 
 ### Added
-* Added `Document Info` API in `DocumentConverter`.
-
+* `Document Info` API added in `DocumentConverter`.
 ## 4.4.1 — 2024-04-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -556,7 +556,7 @@ An `Add-On` is an application implemented by Uploadcare that accepts uploaded fi
 ##### AWS Rekognition
 
 ```ruby
-# Execute AWS Rekognition Add-On for a given target to detect labels in an image. 
+# Execute AWS Rekognition Add-On for a given target to detect labels in an image.
 # Note: Detected labels are stored in the file's appdata.
 Uploadcare::Addons.ws_rekognition_detect_labels('FILE_UUID')
 
@@ -567,7 +567,7 @@ Uploadcare::Addons.ws_rekognition_detect_labels_status('RETURNED_ID_FROM_WS_REKO
 ##### AWS Rekognition Moderation
 
 ```ruby
-# Execute AWS Rekognition Moderation Add-On for a given target to detect moderation labels in an image. 
+# Execute AWS Rekognition Moderation Add-On for a given target to detect moderation labels in an image.
 # Note: Detected moderation labels are stored in the file's appdata.
 
 Uploadcare::Addons.ws_rekognition_detect_moderation_labels('FILE_UUID')
@@ -738,6 +738,20 @@ More examples and options can be found [here](https://uploadcare.com/docs/transf
 ##### Document
 
 After each document file upload you obtain a file identifier in UUID format.
+
+You can use file identifier to determine the document format and possible conversion formats.
+```ruby
+Uploadcare::DocumentConverter.info("dc99200d-9bd6-4b43-bfa9-aa7bfaefca40")
+
+# Response
+{:error=>nil, :format=>{
+  :name=>"jpg",
+  :conversion_formats=>[
+    {:name=>"avif"}, {:name=>"bmp"}, {:name=>"gif"}, {:name=>"ico"}, {:name=>"pcx"}, {:name=>"pdf"}, {:name=>"png"}, {:name=>"ps"}, {:name=>"svg"}, {:name=>"tga"}, {:name=>"thumbnail"}, {:name=>"tiff"}, {:name=>"wbmp"}, {:name=>"webp"}
+  ]
+}}
+```
+
 Then you can use this file identifier to convert your document to a new format:
 
 ```ruby
@@ -841,7 +855,7 @@ You can use custom domain and CDN provider to deliver files with authenticated U
 To generate authenticated URL from the library, you should choose `Uploadcare::SignedUrlGenerators::AkamaiGenerator` (or create your own generator implementation):
 
 ```ruby
-generator = Uploadcare::SignedUrlGenerators::AkamaiGenerator.new(cdn_host: 'example.com', secret_key: 'secret_key') 
+generator = Uploadcare::SignedUrlGenerators::AkamaiGenerator.new(cdn_host: 'example.com', secret_key: 'secret_key')
 # Optional parameters: ttl: 300, algorithm: 'sha256'
 generator.generate_url(uuid, acl = optional)
 
@@ -849,13 +863,13 @@ generator.generate_url("a7d5645e-5cd7-4046-819f-a6a2933bafe3")
 # https://example.com/a7d5645e-5cd7-4046-819f-a6a2933bafe3/?token=exp=1649405263~acl=/a7d5645e-5cd7-4046-819f-a6a2933bafe3/~hmac=a989cae5342f17013677f5a0e6577fc5594cc4e238fb4c95eda36634eb47018b
 
 # You can pass in ACL as a second parameter to generate_url. See https://uploadcare.com/docs/security/secure-delivery/#authenticated-urls for supported acl formats
-generator.generate_url("a7d5645e-5cd7-4046-819f-a6a2933bafe3", '/*/') 
+generator.generate_url("a7d5645e-5cd7-4046-819f-a6a2933bafe3", '/*/')
 # https://example.com/a7d5645e-5cd7-4046-819f-a6a2933bafe3/?token=exp=1649405263~acl=/*/~hmac=3ce1152c6af8864b36d4dc721f08ca3cf0b3a20278d7f849e82c6c930d48ccc1
 
 # Optionally you can use wildcard: true to generate a wildcard acl token
 generator.generate_url("a7d5645e-5cd7-4046-819f-a6a2933bafe3", wildcard: true)
 # https://example.com/a7d5645e-5cd7-4046-819f-a6a2933bafe3/?token=exp=1714233449~acl=/a7d5645e-5cd7-4046-819f-a6a2933bafe3/*~hmac=a568ee2a85dd90a8a8a1ef35ea0cc0ef0acb84fe81990edd3a06eacf10a52b4e
- 
+
 # You can also pass in a custom ttl and algorithm to AkamaiGenerator
 generator = Uploadcare::SignedUrlGenerators::AkamaiGenerator.new(cdn_host: 'example.com', secret_key: 'secret_key', ttl: 10)
 generator.generate_url("a7d5645e-5cd7-4046-819f-a6a2933bafe3")

--- a/lib/uploadcare/client/conversion/document_conversion_client.rb
+++ b/lib/uploadcare/client/conversion/document_conversion_client.rb
@@ -22,6 +22,10 @@ module Uploadcare
           get(uri: "/convert/document/status/#{token}/")
         end
 
+        def document_info(uuid)
+          get(uri: "/convert/document/#{uuid}/")
+        end
+
         private
 
         def convert_uri

--- a/lib/uploadcare/entity/conversion/base_converter.rb
+++ b/lib/uploadcare/entity/conversion/base_converter.rb
@@ -23,6 +23,9 @@ module Uploadcare
             conversion_client.new.get_conversion_status(token)
           end
 
+          # Returns the document format and possible conversion formats.
+          #
+          # @param uuid [String] UUID of the document
           def info(uuid)
             conversion_client.new.document_info(uuid)
           end

--- a/lib/uploadcare/entity/conversion/base_converter.rb
+++ b/lib/uploadcare/entity/conversion/base_converter.rb
@@ -23,6 +23,10 @@ module Uploadcare
             conversion_client.new.get_conversion_status(token)
           end
 
+          def info(uuid)
+            conversion_client.new.document_info(uuid)
+          end
+
           private
 
           def conversion_client

--- a/spec/fixtures/vcr_cassettes/document_convert_info.yml
+++ b/spec/fixtures/vcr_cassettes/document_convert_info.yml
@@ -1,0 +1,60 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.uploadcare.com/convert/document/cd7a51d4-9776-4749-b749-c9fc691891f1/
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/vnd.uploadcare-v0.7+json
+      User-Agent:
+      - UploadcareRuby/4.4.1/demopublickey (Ruby/3.1.3)
+      Date:
+      - Tue, 30 Apr 2024 12:30:58 GMT
+      Authorization:
+      - Uploadcare demopublickey:219d67acad8d30c4b33e2eb4b14359bb1d82ebd8
+      Connection:
+      - close
+      Host:
+      - api.uploadcare.com
+  response:
+    status:
+      code: 200
+      message: ok
+    headers:
+      Date:
+      - Tue, 30 Apr 2024 12:31:00 GMT
+      Content-Type:
+      - text/html; charset=utf-8
+      Content-Length:
+      - '62'
+      Connection:
+      - close
+      Server:
+      - nginx
+      Vary:
+      - Accept
+      - Accept-Encoding
+      Warning:
+      - '199 Miscellaneous warning: You are using the demo project'
+      Access-Control-Allow-Origin:
+      - https://uploadcare.com
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Uploadcare-Request-Id:
+      - '0797972e-39d6-4636-8385-8666c9d3c98f'
+      X-Frame-Options:
+      - SAMEORIGIN
+    body:
+      encoding: UTF-8
+      string: '{"error":null, "format":{"name":"jpg", "conversion_formats":[{"name":"avif"}, {"name":"bmp"}, {"name":"gif"}, {"name":"ico"}, {"name":"pcx"}, {"name":"pdf"}, {"name":"png"}, {"name":"ps"}, {"name":"svg"}, {"name":"tga"}, {"name":"thumbnail"}, {"name":"tiff"}, {"name":"wbmp"}, {"name":"webp"}]}}'
+  recorded_at: Tue, 30 Apr 2024 12:31:00 GMT
+recorded_with: VCR 6.2.0

--- a/spec/uploadcare/entity/conversion/document_converter_spec.rb
+++ b/spec/uploadcare/entity/conversion/document_converter_spec.rb
@@ -66,9 +66,9 @@ module Uploadcare
             VCR.use_cassette('document_convert_info') do
               uuid = 'cd7a51d4-9776-4749-b749-c9fc691891f1'
               response = subject.info(uuid)
-              expect(response.value!.has_key?(:format)).to be_truthy
+              expect(response.value!.key?(:format)).to be_truthy
               document_formats = response.value![:format]
-              expect(document_formats.has_key?(:conversion_formats)).to be_truthy
+              expect(document_formats.key?(:conversion_formats)).to be_truthy
             end
           end
         end

--- a/spec/uploadcare/entity/conversion/document_converter_spec.rb
+++ b/spec/uploadcare/entity/conversion/document_converter_spec.rb
@@ -60,6 +60,18 @@ module Uploadcare
             end
           end
         end
+
+        describe 'info' do
+          it 'shows info about that document' do
+            VCR.use_cassette('document_convert_info') do
+              uuid = 'cd7a51d4-9776-4749-b749-c9fc691891f1'
+              response = subject.info(uuid)
+              expect(response.value!.has_key?(:format)).to be_truthy
+              document_formats = response.value![:format]
+              expect(document_formats.has_key?(:conversion_formats)).to be_truthy
+            end
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
## Description

- Add conversion document info API
- While working on https://github.com/uploadcare/uploadcare-ruby/issues/143 I saw that this one is missing, so adding before that

## Checklist

- [ ] Tests (if applicable)
- [ ] Documentation (if applicable)
- [ ] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Introduced a new `Document Info` API to retrieve detailed information about documents.

- **Documentation**
  - Updated README.md with corrected typos and expanded examples for better clarity and usability.
  - Added a code snippet for using a file identifier to determine document format and conversion formats.
  - Provided examples for generating authenticated URLs using `Uploadcare::SignedUrlGenerators::AkamaiGenerator`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->