### PR TITLE
Fix Uploadcare::File.remote_copy raising response errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Fixed
+* Fixed that `Uploadcare::File.remote_copy` method raised `ApiStruct::EntityError: {url} must be Hash` error. Added string as response instead of `File` entity instance.
+ 
 ### Added
 * `Document Info` API added in `DocumentConverter`.
 ## 4.4.1 — 2024-04-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,7 @@
 ## Unreleased
 
 ### Fixed
-* Fixed that `Uploadcare::File.remote_copy` method raised `ApiStruct::EntityError: {url} must be Hash` error. Added string as response instead of `File` entity instance.
- 
+* Fixed the `Uploadcare::File.remote_copy` method which raised an `ApiStruct::EntityError: {url} must be Hash`. Now returns a string instead of a `File` entity instance.
 ### Added
 * `Document Info` API added in `DocumentConverter`.
 ## 4.4.1 — 2024-04-27

--- a/api_examples/rest_api/post_files_remote_copy.rb
+++ b/api_examples/rest_api/post_files_remote_copy.rb
@@ -2,7 +2,7 @@ require 'uploadcare'
 Uploadcare.config.public_key = 'YOUR_PUBLIC_KEY'
 Uploadcare.config.secret_key = 'YOUR_SECRET_KEY'
 
-source = '1bac376c-aa7e-4356-861b-dd2657b5bfd2'
+source_object = '1bac376c-aa7e-4356-861b-dd2657b5bfd2'
 target = 'custom_storage_connected_to_the_project'
-copied_file = Uploadcare::File.remote_copy(source, target, make_public: true)
-puts copied_file.uuid
+copied_file_url = Uploadcare::File.remote_copy(source_object, target, make_public: true)
+puts copied_file_url

--- a/lib/uploadcare/client/multipart_upload_client.rb
+++ b/lib/uploadcare/client/multipart_upload_client.rb
@@ -47,7 +47,7 @@ module Uploadcare
       private
 
       def form_data_for(file)
-        form_data_file = super(file)
+        form_data_file = super
         {
           filename: form_data_file.filename,
           size: form_data_file.size,

--- a/lib/uploadcare/entity/file.rb
+++ b/lib/uploadcare/entity/file.rb
@@ -64,8 +64,7 @@ module Uploadcare
       #
       # @see https://uploadcare.com/api-refs/rest-api/v0.7.0/#tag/File/operation/createRemoteCopy
       def self.remote_copy(source, target, args = {})
-        response = FileClient.new.remote_copy(source: source, target: target, **args).success[:result]
-        File.new(response)
+        FileClient.new.remote_copy(source: source, target: target, **args).success[:result]
       end
 
       # Instance version of {internal_copy}

--- a/spec/fixtures/vcr_cassettes/rest_file_remote_copy.yml
+++ b/spec/fixtures/vcr_cassettes/rest_file_remote_copy.yml
@@ -1,0 +1,115 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.uploadcare.com/files/1b959c59-9605-4879-946f-08fdb5ea3e9d/
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/vnd.uploadcare-v0.7+json
+      User-Agent:
+      - UploadcareRuby/4.4.1/<uploadcare_public_key> (Ruby/3.3.0)
+      Date:
+      - Tue, 28 May 2024 14:25:46 GMT
+      Authorization:
+      - "<Uploadcare token>"
+      Connection:
+      - close
+      Host:
+      - api.uploadcare.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 28 May 2024 14:25:47 GMT
+      Content-Type:
+      - application/vnd.uploadcare-v0.7+json
+      Content-Length:
+      - '712'
+      Connection:
+      - close
+      Server:
+      - nginx
+      Access-Control-Allow-Origin:
+      - https://uploadcare.com
+      Vary:
+      - Accept
+      Allow:
+      - DELETE, GET, HEAD, OPTIONS
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Uploadcare-Request-Id:
+      - f015aae5-5123-4ec7-9a00-f6f168b8f27a
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"datetime_removed":null,"datetime_stored":"2024-05-23T22:39:29.307033Z","datetime_uploaded":"2024-05-23T22:39:29.139028Z","is_image":true,"is_ready":true,"mime_type":"image/png","original_file_url":"https://ucarecdn.com/1b959c59-9605-4879-946f-08fdb5ea3e9d/image.png","original_filename":"image.png","size":1048620,"url":"https://api.uploadcare.com/files/1b959c59-9605-4879-946f-08fdb5ea3e9d/","uuid":"1b959c59-9605-4879-946f-08fdb5ea3e9d","variations":null,"content_info":{"mime":{"mime":"image/png","type":"image","subtype":"png"},"image":{"dpi":null,"width":2560,"format":"PNG","height":523,"sequence":false,"color_mode":"RGBA","orientation":null,"geo_location":null,"datetime_original":null}},"metadata":{}}'
+  recorded_at: Tue, 28 May 2024 14:25:47 GMT
+- request:
+    method: post
+    uri: https://api.uploadcare.com/files/remote_copy/
+    body:
+      encoding: UTF-8
+      string: '{"source":"1b959c59-9605-4879-946f-08fdb5ea3e9d","target":"uploadcare-test"}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/vnd.uploadcare-v0.7+json
+      User-Agent:
+      - UploadcareRuby/4.4.1/<uploadcare_public_key> (Ruby/3.3.0)
+      Date:
+      - Tue, 28 May 2024 14:25:47 GMT
+      Authorization:
+      - "<Uploadcare token>"
+      Connection:
+      - close
+      Host:
+      - api.uploadcare.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 28 May 2024 14:25:48 GMT
+      Content-Type:
+      - application/vnd.uploadcare-v0.7+json
+      Content-Length:
+      - '99'
+      Connection:
+      - close
+      Server:
+      - nginx
+      Access-Control-Allow-Origin:
+      - https://uploadcare.com
+      Vary:
+      - Accept
+      Allow:
+      - OPTIONS, POST
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Uploadcare-Request-Id:
+      - aea85827-bab0-4760-865a-2dd43a830d5f
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"type":"url","result":"s3://uploadcare-test/1b959c59-9605-4879-946f-08fdb5ea3e9d/image.png"}'
+  recorded_at: Tue, 28 May 2024 14:25:48 GMT
+recorded_with: VCR 6.2.0

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -6,6 +6,8 @@ require 'vcr'
 VCR.configure do |config|
   config.cassette_library_dir = 'spec/fixtures/vcr_cassettes'
   config.hook_into :webmock
+  config.filter_sensitive_data('<uploadcare_public_key>') { Uploadcare.config.public_key }
+  config.filter_sensitive_data('<uploadcare_secret_key>') { Uploadcare.config.secret_key }
   config.before_record do |i|
     if i.request.body && i.request.body.size > 1024 * 1024
       i.request.body = "Big string (#{i.request.body.size / (1024 * 1024)}) MB"

--- a/spec/uploadcare/entity/file_spec.rb
+++ b/spec/uploadcare/entity/file_spec.rb
@@ -44,7 +44,16 @@ module Uploadcare
       end
 
       describe 'external_copy' do
-        it 'copies file to different project' do
+        it 'copies file to remote storage' do
+          VCR.use_cassette('rest_file_remote_copy') do
+            target = 'uploadcare-test'
+            uuid = '1b959c59-9605-4879-946f-08fdb5ea3e9d'
+            file = subject.file(uuid)
+            expect(file.remote_copy(target)).to match(%r{#{target}/#{uuid}/})
+          end
+        end
+
+        it 'raises an error when project does not have given storage' do
           VCR.use_cassette('rest_file_external_copy') do
             file = subject.file('5632fc94-9dff-499f-a373-f69ea6f67ff8')
             # I don't have custom storage, but this error recognises what this method tries to do


### PR DESCRIPTION
## Description

- Fix Uploadcare::File.remote_copy raising response errors

## Checklist

- [x] Tests (if applicable)
- [x] Documentation (if applicable)
- [x] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue in the `Uploadcare::File.remote_copy` method to prevent errors related to input parameter type.

- **Enhancements**
  - Improved variable naming in REST API examples for better clarity.
  - Updated the `remote_copy` method to return a string instead of a `File` entity instance.

- **Security**
  - Introduced filtering for sensitive data (`<uploadcare_public_key>` and `<uploadcare_secret_key>`) in test configurations.

- **Testing**
  - Added new test cases for remote file copying and error handling for invalid storage in the project.
  - Included VCR cassette for HTTP interactions with the Uploadcare API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->