### PR TITLE
Prepare for a new release [4.4.2]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,13 @@
 # Changelog
 
-## Unreleased
+## 4.4.2 — 2024-05-29
 
 ### Fixed
 * Fixed the `Uploadcare::File.remote_copy` method which raised an `ApiStruct::EntityError: {url} must be Hash`. Now returns a string instead of a `File` entity instance.
+
 ### Added
 * `Document Info` API added in `DocumentConverter`.
+
 ## 4.4.1 — 2024-04-27
 
 ### Added

--- a/lib/uploadcare/ruby/version.rb
+++ b/lib/uploadcare/ruby/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Uploadcare
-  VERSION = '4.4.1'
+  VERSION = '4.4.2'
 end


### PR DESCRIPTION
## Description

- Prepare for a new release [4.4.2]. Changes as below:

### Fixed
* Fixed the `Uploadcare::File.remote_copy` method which raised an `ApiStruct::EntityError: {url} must be Hash`. Now returns a string instead of a `File` entity instance.

### Added
* `Document Info` API added in `DocumentConverter`.


## Checklist

- [ ] Tests (if applicable)
- [ ] Documentation (if applicable)
- [x] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a `Document Info` API to the DocumentConverter.

- **Bug Fixes**
  - Fixed the `Uploadcare::File.remote_copy` method to return a string instead of a `File` entity instance.

- **Chores**
  - Updated the software version to 4.4.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->