### PR TITLE
Add multipage conversion (save_in_group) parameter to document conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Added
+* Multi page conversion parameter (`save_in_group`) added to `DocumentConverter#convert` options.
+
 ## 4.4.2 — 2024-05-29
 
 ### Fixed

--- a/api_examples/rest_api/post_convert_document.rb
+++ b/api_examples/rest_api/post_convert_document.rb
@@ -3,5 +3,7 @@ Uploadcare.config.public_key = 'YOUR_PUBLIC_KEY'
 Uploadcare.config.secret_key = 'YOUR_SECRET_KEY'
 
 document_params = { uuid: '1bac376c-aa7e-4356-861b-dd2657b5bfd2', format: :pdf }
-options = { store: true }
+options = { store: '1' }
+# for multipage conversion
+# options = { store: '1', save_in_group: '1' }
 Uploadcare::DocumentConverter.convert(document_params, options)

--- a/lib/uploadcare/client/conversion/base_conversion_client.rb
+++ b/lib/uploadcare/client/conversion/base_conversion_client.rb
@@ -50,7 +50,8 @@ module Uploadcare
                 **build_paths_body(params)
               )
             end,
-            store: options[:store]
+            store: options[:store],
+            save_in_group: options[:save_in_group]
           }.compact.to_json
         end
       end

--- a/spec/fixtures/vcr_cassettes/document_convert_convert_multipage_group.yml
+++ b/spec/fixtures/vcr_cassettes/document_convert_convert_multipage_group.yml
@@ -1,0 +1,118 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.uploadcare.com/convert/document/
+    body:
+      encoding: UTF-8
+      string: '{"paths":["23d29586-713e-4152-b400-05fb54730453/document/-/format/jpg/"],"store":"0","save_in_group":"1"}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/vnd.uploadcare-v0.7+json
+      User-Agent:
+      - UploadcareRuby/4.4.2/<uploadcare_public_key> (Ruby/3.3.0)
+      Date:
+      - Thu, 20 Jun 2024 12:14:07 GMT
+      Authorization:
+      - Uploadcare <uploadcare_public_key>:<uploadcare_auth>
+      Connection:
+      - close
+      Host:
+      - api.uploadcare.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 20 Jun 2024 12:14:09 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '179'
+      Connection:
+      - close
+      Server:
+      - nginx
+      Vary:
+      - Accept
+      - Accept-Encoding
+      Access-Control-Allow-Origin:
+      - https://uploadcare.com
+      Allow:
+      - OPTIONS, POST
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Uploadcare-Request-Id:
+      - d5ba6783-f33d-48b7-b567-f9eda216a17d
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: UTF-8
+      string: '{"result": [{"original_source": "23d29586-713e-4152-b400-05fb54730453/document/-/format/jpg/",
+        "token": 44428559, "uuid": "d586b32a-9b5b-4209-94ad-b79761f5b57f"}], "problems":
+        {}}'
+  recorded_at: Thu, 20 Jun 2024 12:14:09 GMT
+- request:
+    method: get
+    uri: https://api.uploadcare.com/convert/document/23d29586-713e-4152-b400-05fb54730453/
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/vnd.uploadcare-v0.7+json
+      User-Agent:
+      - UploadcareRuby/4.4.2/<uploadcare_public_key> (Ruby/3.3.0)
+      Date:
+      - Thu, 20 Jun 2024 12:14:09 GMT
+      Authorization:
+      - Uploadcare <uploadcare_public_key>:<uploadcare_auth>
+      Connection:
+      - close
+      Host:
+      - api.uploadcare.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 20 Jun 2024 12:14:10 GMT
+      Content-Type:
+      - application/vnd.uploadcare-v0.7+json
+      Content-Length:
+      - '778'
+      Connection:
+      - close
+      Server:
+      - nginx
+      Access-Control-Allow-Origin:
+      - https://uploadcare.com
+      Vary:
+      - Accept
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Uploadcare-Request-Id:
+      - 4b26200c-ef3d-48f9-8073-f6d9a4fe237e
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"error":null,"format":{"name":"pdf","conversion_formats":[{"name":"bmp"},{"name":"csv"},{"name":"doc"},{"name":"docx"},{"name":"dwg"},{"name":"dxf"},{"name":"enhanced.jpg"},{"name":"epub"},{"name":"fb2"},{"name":"gif"},{"name":"html"},{"name":"html5"},{"name":"html5-1page"},{"name":"htmlz"},{"name":"jpg"},{"name":"lit"},{"name":"lrf"},{"name":"md"},{"name":"mobi"},{"name":"mp3"},{"name":"pcx"},{"name":"pdb"},{"name":"png"},{"name":"ppt"},{"name":"pptx"},{"name":"prc"},{"name":"ps"},{"name":"rb"},{"name":"rtf"},{"name":"snb"},{"name":"svg"},{"name":"tcr"},{"name":"thumbnail"},{"name":"tiff"},{"name":"txt"},{"name":"txtz"},{"name":"xls"},{"name":"xlsx"}],"converted_groups":{"png":"88d59cae-c88d-459d-b99b-a87a6a2519d0~2","jpg":"69fe5a35-e5e5-449d-9287-e8453f76aab3~2"}}}'
+  recorded_at: Thu, 20 Jun 2024 12:14:10 GMT
+recorded_with: VCR 6.2.0

--- a/spec/fixtures/vcr_cassettes/document_convert_convert_multipage_zip.yml
+++ b/spec/fixtures/vcr_cassettes/document_convert_convert_multipage_zip.yml
@@ -1,0 +1,118 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.uploadcare.com/convert/document/
+    body:
+      encoding: UTF-8
+      string: '{"paths":["d95309eb-50bd-4594-bd7a-950011578480/document/-/format/jpg/"],"store":"1","save_in_group":"0"}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/vnd.uploadcare-v0.7+json
+      User-Agent:
+      - UploadcareRuby/4.4.2/<uploadcare_public_key> (Ruby/3.3.0)
+      Date:
+      - Thu, 20 Jun 2024 12:01:04 GMT
+      Authorization:
+      - Uploadcare <uploadcare_public_key>:<uploadcare_auth>
+      Connection:
+      - close
+      Host:
+      - api.uploadcare.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 20 Jun 2024 12:01:06 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '179'
+      Connection:
+      - close
+      Server:
+      - nginx
+      Vary:
+      - Accept
+      - Accept-Encoding
+      Access-Control-Allow-Origin:
+      - https://uploadcare.com
+      Allow:
+      - OPTIONS, POST
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Uploadcare-Request-Id:
+      - dcc60a86-38cb-4836-a037-8279b60e97ab
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: UTF-8
+      string: '{"result": [{"original_source": "d95309eb-50bd-4594-bd7a-950011578480/document/-/format/jpg/",
+        "token": 44428259, "uuid": "ddf298c3-6113-465b-8677-1f566cced4f1"}], "problems":
+        {}}'
+  recorded_at: Thu, 20 Jun 2024 12:01:06 GMT
+- request:
+    method: get
+    uri: https://api.uploadcare.com/convert/document/d95309eb-50bd-4594-bd7a-950011578480/
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/vnd.uploadcare-v0.7+json
+      User-Agent:
+      - UploadcareRuby/4.4.2/<uploadcare_public_key> (Ruby/3.3.0)
+      Date:
+      - Thu, 20 Jun 2024 12:01:06 GMT
+      Authorization:
+      - Uploadcare <uploadcare_public_key>:<uploadcare_auth>
+      Connection:
+      - close
+      Host:
+      - api.uploadcare.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 20 Jun 2024 12:01:07 GMT
+      Content-Type:
+      - application/vnd.uploadcare-v0.7+json
+      Content-Length:
+      - '663'
+      Connection:
+      - close
+      Server:
+      - nginx
+      Access-Control-Allow-Origin:
+      - https://uploadcare.com
+      Vary:
+      - Accept
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Uploadcare-Request-Id:
+      - 6caab90a-9fc0-4194-a092-480e8ce65ff9
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"error":null,"format":{"name":"pdf","conversion_formats":[{"name":"bmp"},{"name":"csv"},{"name":"doc"},{"name":"docx"},{"name":"dwg"},{"name":"dxf"},{"name":"enhanced.jpg"},{"name":"epub"},{"name":"fb2"},{"name":"gif"},{"name":"html"},{"name":"html5"},{"name":"html5-1page"},{"name":"htmlz"},{"name":"jpg"},{"name":"lit"},{"name":"lrf"},{"name":"md"},{"name":"mobi"},{"name":"mp3"},{"name":"pcx"},{"name":"pdb"},{"name":"png"},{"name":"ppt"},{"name":"pptx"},{"name":"prc"},{"name":"ps"},{"name":"rb"},{"name":"rtf"},{"name":"snb"},{"name":"svg"},{"name":"tcr"},{"name":"thumbnail"},{"name":"tiff"},{"name":"txt"},{"name":"txtz"},{"name":"xls"},{"name":"xlsx"}]}}'
+  recorded_at: Thu, 20 Jun 2024 12:01:07 GMT
+recorded_with: VCR 6.2.0

--- a/spec/fixtures/vcr_cassettes/document_convert_to_multipage.yml
+++ b/spec/fixtures/vcr_cassettes/document_convert_to_multipage.yml
@@ -1,0 +1,62 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.uploadcare.com/convert/document/
+    body:
+      encoding: UTF-8
+      string: '{"paths":["23d29586-713e-4152-b400-05fb54730453/document/-/format/png/"],"store":"0","save_in_group":"1"}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/vnd.uploadcare-v0.7+json
+      User-Agent:
+      - UploadcareRuby/4.4.2/<uploadcare_public_key> (Ruby/3.3.0)
+      Date:
+      - Thu, 20 Jun 2024 11:27:39 GMT
+      Authorization:
+      - Uploadcare <uploadcare_public_key>:<uploadcare_auth>
+      Connection:
+      - close
+      Host:
+      - api.uploadcare.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 20 Jun 2024 11:27:41 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '179'
+      Connection:
+      - close
+      Server:
+      - nginx
+      Vary:
+      - Accept
+      - Accept-Encoding
+      Access-Control-Allow-Origin:
+      - https://uploadcare.com
+      Allow:
+      - OPTIONS, POST
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Uploadcare-Request-Id:
+      - 3bfdd243-a700-4a53-93c5-f3bbbbdf6efa
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: UTF-8
+      string: '{"result": [{"original_source": "23d29586-713e-4152-b400-05fb54730453/document/-/format/png/",
+        "token": 44427572, "uuid": "44c011c3-de82-4c65-81ac-2738c741bec5"}], "problems":
+        {}}'
+  recorded_at: Thu, 20 Jun 2024 11:27:41 GMT
+recorded_with: VCR 6.2.0

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -13,4 +13,5 @@ VCR.configure do |config|
       i.request.body = "Big string (#{i.request.body.size / (1024 * 1024)}) MB"
     end
   end
+  config.configure_rspec_metadata!
 end

--- a/spec/uploadcare/client/conversion/document_conversion_client_spec.rb
+++ b/spec/uploadcare/client/conversion/document_conversion_client_spec.rb
@@ -12,9 +12,7 @@ module Uploadcare
 
             shared_examples 'succeeds documents conversion' do
               it 'returns a convert documents response' do
-                VCR.use_cassette('document_convert_convert_many') do
-                  expect(subject).to be_success
-                end
+                expect(subject).to be_success
               end
             end
 
@@ -29,7 +27,21 @@ module Uploadcare
             end
             let(:options) { { store: false } }
 
-            context 'when all params are present' do
+            context 'when all params are present', vcr: 'document_convert_convert_many' do
+              it_behaves_like 'succeeds documents conversion'
+            end
+
+            context 'multipage conversion', vcr: 'document_convert_to_multipage' do
+              let(:array_of_params) do
+                [
+                  {
+                    uuid: '23d29586-713e-4152-b400-05fb54730453',
+                    format: 'png'
+                  }
+                ]
+              end
+              let(:options) { { store: '0', save_in_group: '1' } }
+
               it_behaves_like 'succeeds documents conversion'
             end
           end

--- a/spec/uploadcare/entity/conversion/document_converter_spec.rb
+++ b/spec/uploadcare/entity/conversion/document_converter_spec.rb
@@ -8,19 +8,29 @@ module Uploadcare
       RSpec.describe DocumentConverter do
         subject { Uploadcare::DocumentConverter }
 
-        describe 'convert_many' do
-          shared_examples 'converts documents' do
+        describe 'convert' do
+          shared_examples 'converts documents' do |multipage: false, group: false|
             it 'returns a result with document data', :aggregate_failures do
-              VCR.use_cassette('document_convert_convert_many') do
-                response_value = subject.convert(params, **options).success
-                result = response_value[:result].first
+              response_value = subject.convert(params, **options).success
+              result = response_value[:result].first
 
-                expect(response_value[:problems]).to be_empty
-                expect(result[:uuid]).not_to be_nil
+              expect(response_value[:problems]).to be_empty
+              expect(result[:uuid]).not_to be_nil
 
-                [doc_params[:uuid], :format, :page].each do |param|
-                  expect(result[:original_source]).to match(param.to_s)
-                end
+              [doc_params[:uuid], :format].each do |param|
+                expect(result[:original_source]).to match(param.to_s)
+              end
+              expect(result[:original_source]).to match('page') if doc_params[:page]
+
+              next unless multipage
+
+              info_response_values = subject.info(doc_params[:uuid]) # get info about that document
+              if group
+                expect(
+                  info_response_values.success.dig(:format, :converted_groups, doc_params[:format].to_sym)
+                ).not_to be_empty
+              else
+                expect(info_response_values.success.dig(:format, :converted_groups)).to be_nil
               end
             end
           end
@@ -34,20 +44,49 @@ module Uploadcare
           end
           let(:options) { { store: false } }
 
-          context 'when sending params as an Array' do
+          context 'when sending params as an Array', vcr: 'document_convert_convert_many' do
             let(:params) { [doc_params] }
 
             it_behaves_like 'converts documents'
           end
 
-          context 'when sending params as a Hash' do
+          context 'when sending params as a Hash', vcr: 'document_convert_convert_many' do
             let(:params) { doc_params }
 
             it_behaves_like 'converts documents'
           end
+
+          # Ref: https://uploadcare.com/docs/transformations/document-conversion/#multipage-conversion
+          describe 'multipage conversion' do
+            context 'when not saved in group', vcr: 'document_convert_convert_multipage_zip' do
+              let(:doc_params) do
+                {
+                  uuid: 'd95309eb-50bd-4594-bd7a-950011578480',
+                  format: 'jpg'
+                }
+              end
+              let(:options) { { store: '1', save_in_group: '0' } }
+              let(:params) { doc_params }
+
+              it_behaves_like 'converts documents', { multipage: true, group: false }
+            end
+
+            context 'when saved in group', vcr: 'document_convert_convert_multipage_group' do
+              let(:doc_params) do
+                {
+                  uuid: '23d29586-713e-4152-b400-05fb54730453',
+                  format: 'jpg'
+                }
+              end
+              let(:options) { { store: '0', save_in_group: '1' } }
+              let(:params) { doc_params }
+
+              it_behaves_like 'converts documents', { multipage: true, group: true }
+            end
+          end
         end
 
-        describe 'get video conversion status' do
+        describe 'get document conversion status' do
           let(:token) { '21120333' }
 
           it 'returns a document conversion status data', :aggregate_failures do


### PR DESCRIPTION
## Description

Add multipage conversion (save_in_group) parameter to document conversion

## Checklist

- [x] Tests (if applicable)
- [x] Documentation (if applicable)
- [x] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added multi-page conversion option to document conversion API (`save_in_group` parameter).

- **Tests**
  - Updated test cases to cover new multi-page conversion functionality.
  - Added new VCR cassettes for multipage conversion scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->