### PR TITLE
Fix that Signed urls did not work with nth notation for groups as well as when using ~ in URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Added
 * Multi page conversion parameter (`save_in_group`) added to `DocumentConverter#convert` options.
 
+### Fixed
+* Fixed that signed URLs now work with ~ in the path. This also fixes signed URLs with grouped file URLs. 
+
 ## 4.4.2 — 2024-05-29
 
 ### Fixed

--- a/lib/uploadcare/signed_url_generators/akamai_generator.rb
+++ b/lib/uploadcare/signed_url_generators/akamai_generator.rb
@@ -35,10 +35,15 @@ module Uploadcare
 
       def build_acl(uuid, acl, wildcard: false)
         if wildcard
-          "/#{sanitized_string(uuid)}/*"
+          "/#{sanitized_delimiter_path(uuid)}/*"
         else
-          "/#{sanitized_string(acl)}/"
+          "/#{sanitized_delimiter_path(acl)}/"
         end
+      end
+
+      # Delimiter sanitization referenced from: https://github.com/uploadcare/pyuploadcare/blob/main/pyuploadcare/secure_url.py#L74
+      def sanitized_delimiter_path(path)
+        sanitized_string(path).gsub('~') { |escape_char| "%#{escape_char.ord.to_s(16).downcase}" }
       end
 
       def build_expire

--- a/spec/uploadcare/signed_url_generators/akamai_generator_spec.rb
+++ b/spec/uploadcare/signed_url_generators/akamai_generator_spec.rb
@@ -54,6 +54,24 @@ module Uploadcare
           expect(subject.generate_url(uuid, nil, wildcard: true)).to eq expected_url
         end
       end
+
+      context 'works with group' do
+        let(:uuid) { '83a8994a-e0b4-4091-9a10-5a847298e493~4' }
+
+        it 'returns correct url' do
+          expected_url = 'https://example.com/83a8994a-e0b4-4091-9a10-5a847298e493~4/?token=exp=1649343900~acl=/83a8994a-e0b4-4091-9a10-5a847298e493%7e4/*~hmac=f4d4c5da93324dffa2b5bb42d8a6cc693789077212cbdf599fe3220b9d37749d'
+          expect(subject.generate_url(uuid, nil, wildcard: true)).to eq expected_url
+        end
+      end
+
+      context 'works with nth file type notation for files within a group' do
+        let(:uuid) { '83a8994a-e0b4-4091-9a10-5a847298e493~4/nth/0/-/crop/250x250/1000,1000' }
+
+        it 'returns correct url' do
+          expected_url = 'https://example.com/83a8994a-e0b4-4091-9a10-5a847298e493~4/nth/0/-/crop/250x250/1000,1000/?token=exp=1649343900~acl=/83a8994a-e0b4-4091-9a10-5a847298e493%7e4/nth/0/-/crop/250x250/1000,1000/*~hmac=d483cfa64cffe617c1cc72d6f1d3287a74d27cb608bbf08dc07d3d61e29cd4be'
+          expect(subject.generate_url(uuid, nil, wildcard: true)).to eq expected_url
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Description

Fix that Signed urls did not work with nth notation for groups as well as when using ~ in URLs
Closes #167 #138 

## Checklist

- [x] Tests (if applicable)
- [x] Documentation (if applicable)
- [x] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved signed URLs to handle paths containing `~` correctly.

- **New Features**
  - Enhanced URL generation to support groups and nth file type notation within groups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->