### PR TITLE
Add Context7 configuration

### DIFF
--- a/api_examples/upload_api/post_base.rb
+++ b/api_examples/upload_api/post_base.rb
@@ -2,5 +2,6 @@ require 'uploadcare'
 Uploadcare.config.public_key = 'YOUR_PUBLIC_KEY'
 Uploadcare.config.secret_key = 'YOUR_SECRET_KEY'
 
-source_file = File.open('image.png')
-Uploadcare::Uploader.upload(source_file, store: 'auto')
+File.open('image.png') do |source_file|
+  Uploadcare::Uploader.upload(source_file, store: 'auto')
+end

--- a/api_examples/upload_api/post_multipart_complete.rb
+++ b/api_examples/upload_api/post_multipart_complete.rb
@@ -4,5 +4,6 @@ require 'uploadcare'
 Uploadcare.config.public_key = 'YOUR_PUBLIC_KEY'
 Uploadcare.config.secret_key = 'YOUR_SECRET_KEY'
 
-source_file = File.open('image.png')
-Uploadcare::Uploader.upload(source_file, store: 'auto')
+File.open('image.png') do |source_file|
+  Uploadcare::Uploader.upload(source_file, store: 'auto')
+end

--- a/api_examples/upload_api/post_multipart_start.rb
+++ b/api_examples/upload_api/post_multipart_start.rb
@@ -4,5 +4,6 @@ require 'uploadcare'
 Uploadcare.config.public_key = 'YOUR_PUBLIC_KEY'
 Uploadcare.config.secret_key = 'YOUR_SECRET_KEY'
 
-source_file = File.open('image.png')
-Uploadcare::Uploader.upload(source_file, store: 'auto')
+File.open('image.png') do |source_file|
+  Uploadcare::Uploader.upload(source_file, store: 'auto')
+end

--- a/api_examples/upload_api/put_presigned_url_x.rb
+++ b/api_examples/upload_api/put_presigned_url_x.rb
@@ -4,5 +4,6 @@ require 'uploadcare'
 Uploadcare.config.public_key = 'YOUR_PUBLIC_KEY'
 Uploadcare.config.secret_key = 'YOUR_SECRET_KEY'
 
-source_file = File.open('image.png')
-Uploadcare::Uploader.upload(source_file, store: 'auto')
+File.open('image.png') do |source_file|
+  Uploadcare::Uploader.upload(source_file, store: 'auto')
+end

--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "https://context7.com/schema/context7.json",
+  "projectTitle": "Uploadcare Ruby",
+  "description": "Ruby API client for Uploadcare uploads, file management, conversions, webhooks, add-ons, and signed CDN URLs.",
+  "url": "https://context7.com/uploadcare/uploadcare-ruby",
+  "public_key": "pk_WoigIc3LrHKMjLxnI0IA2",
+  "branch": "main",
+  "folders": [
+    "lib",
+    "api_examples"
+  ],
+  "excludeFolders": [
+    ".github",
+    "bin",
+    "spec",
+    "vendor",
+    "tmp",
+    "coverage",
+    "pkg",
+    "doc",
+    "*archive*",
+    "*archived*",
+    "old",
+    "docs/old",
+    "*deprecated*",
+    "*legacy*",
+    "*previous*",
+    "*outdated*",
+    "*superseded*"
+  ],
+  "excludeFiles": [
+    "CHANGELOG.md",
+    "changelog.md",
+    "CHANGELOG.mdx",
+    "changelog.mdx",
+    "LICENSE",
+    "LICENSE.md",
+    "license.md",
+    "CODE_OF_CONDUCT.md",
+    "code_of_conduct.md",
+    "Gemfile",
+    "Rakefile",
+    "uploadcare-ruby.gemspec",
+    ".rspec",
+    ".rubocop.yml",
+    ".yardopts"
+  ],
+  "rules": [
+    "Install the gem as `uploadcare-ruby` and require it with `require \"uploadcare\"`.",
+    "Configure credentials with `Uploadcare.config.public_key` and `Uploadcare.config.secret_key` or the UPLOADCARE_PUBLIC_KEY and UPLOADCARE_SECRET_KEY environment variables.",
+    "Never hardcode real Uploadcare API keys in examples or application code; use environment variables or an application secrets store.",
+    "Use `Uploadcare::Uploader.upload` for automatic upload method selection and `Uploadcare::Uploader.multipart_upload` for explicit large-file multipart uploads.",
+    "Prefer public entity helpers such as `Uploadcare::File`, `Uploadcare::FileList`, `Uploadcare::Group`, `Uploadcare::Webhook`, and conversion methods over internal clients."
+  ],
+  "previousVersions": [
+    {
+      "tag": "v4.4.3"
+    },
+    {
+      "tag": "v3.3.2"
+    },
+    {
+      "tag": "v2.1.2"
+    },
+    {
+      "tag": "v1.2.2"
+    }
+  ]
+}

--- a/spec/support/generate_file_fixtures.rb
+++ b/spec/support/generate_file_fixtures.rb
@@ -12,8 +12,10 @@ def generate_big_file
   return if File.file?('spec/fixtures/big.jpeg')
 
   FileUtils.cp('spec/fixtures/kitten.jpeg', 'spec/fixtures/big.jpeg')
-  source_file = File.open('spec/fixtures/kitten.jpeg')
-  destination = File.open('spec/fixtures/big.jpeg', 'w')
-  destination.write(source_file.read)
-  destination.write('a' * 10 * 1024 * 1024)
+  File.open('spec/fixtures/kitten.jpeg') do |source_file|
+    File.open('spec/fixtures/big.jpeg', 'w') do |destination|
+      destination.write(source_file.read)
+      destination.write('a' * 10 * 1024 * 1024)
+    end
+  end
 end

--- a/spec/uploadcare/entity/decorator/paginator_spec.rb
+++ b/spec/uploadcare/entity/decorator/paginator_spec.rb
@@ -36,7 +36,9 @@ module Uploadcare
               fl_path = fl_with_params.delete(:next)
               previous_page_path = previous_page.delete(:next)
               expect(fl_with_params).to eq(previous_page)
-              expect(CGI.parse(URI.parse(fl_path).query)).to eq(CGI.parse(URI.parse(previous_page_path).query))
+              fl_query = URI.decode_www_form(URI.parse(fl_path).query).sort
+              previous_page_query = URI.decode_www_form(URI.parse(previous_page_path).query).sort
+              expect(fl_query).to eq(previous_page_query)
             end
           end
         end


### PR DESCRIPTION
## Summary
- Add a root `context7.json` for Context7 indexing and library ownership verification.
- Configure included source/example folders, documentation exclusions, usage rules, and previous version tags.
- Update file-opening examples and fixture generation to use block-form `File.open` for RuboCop compliance.
- Replace a spec-only `CGI.parse` query comparison with `URI.decode_www_form` for CI compatibility.

## Validation
- `ruby -rjson -e 'JSON.parse(File.read("context7.json")); puts "context7.json ok"'`\n- `bundle exec rubocop`\n- `bundle exec rake`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated upload code examples with improved file handling patterns demonstrating proper resource management.

* **Tests**
  * Enhanced pagination test to validate query parameters with more robust comparison logic.

* **Chores**
  * Added new project configuration for the Uploadcare Ruby SDK with schema definitions, metadata, and usage guidelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->