### PR TITLE
Fix Upload API sending Faraday's default User-Agent

### DIFF
--- a/lib/uploadcare/api/upload.rb
+++ b/lib/uploadcare/api/upload.rb
@@ -159,7 +159,7 @@ class Uploadcare::Api::Upload
   end
 
   def prepare_headers(req, _method, _uri, headers)
-    req.headers['User-Agent'] ||= Uploadcare::Internal::UserAgent.call(config: config)
+    req.headers['User-Agent'] = Uploadcare::Internal::UserAgent.call(config: config)
     req.headers.merge!(headers)
   end
 
@@ -243,6 +243,7 @@ class Uploadcare::Api::Upload
   def upload_part_request(conn:, request_uri:, data:, timeout:, open_timeout:)
     conn.put(request_uri) do |req|
       req.headers['Content-Type'] = 'application/octet-stream'
+      req.headers['User-Agent'] = Uploadcare::Internal::UserAgent.call(config: config)
       req.options.timeout = timeout if timeout
       req.options.open_timeout = open_timeout if open_timeout
       req.body = data

--- a/spec/uploadcare/api/rest_spec.rb
+++ b/spec/uploadcare/api/rest_spec.rb
@@ -39,6 +39,22 @@ RSpec.describe Uploadcare::Api::Rest do
     end
   end
 
+  describe 'User-Agent header' do
+    it 'sends the SDK User-Agent on REST API requests, not the Faraday default' do
+      expected_user_agent = Uploadcare::Internal::UserAgent.call(config: config)
+      stub_request(:get, 'https://api.uploadcare.com/files/')
+        .with(headers: { 'User-Agent' => expected_user_agent })
+        .to_return(status: 200, body: '{}', headers: { 'Content-Type' => 'application/json' })
+
+      rest.get(path: '/files/', params: {}, headers: {}, request_options: {})
+
+      expect(
+        a_request(:get, 'https://api.uploadcare.com/files/')
+          .with(headers: { 'User-Agent' => %r{\AUploadcareRuby/} })
+      ).to have_been_made
+    end
+  end
+
   describe '#get' do
     it 'returns a successful Result on 200' do
       stub_request(:get, 'https://api.uploadcare.com/files/')

--- a/spec/uploadcare/api/upload_spec.rb
+++ b/spec/uploadcare/api/upload_spec.rb
@@ -105,6 +105,37 @@ RSpec.describe Uploadcare::Api::Upload do
     end
   end
 
+  describe 'User-Agent header' do
+    let(:expected_user_agent) { Uploadcare::Internal::UserAgent.call(config: config) }
+
+    it 'sends the SDK User-Agent on Upload API requests, not the Faraday default' do
+      stub_request(:post, 'https://upload.uploadcare.com/base/')
+        .with(headers: { 'User-Agent' => expected_user_agent })
+        .to_return(status: 200, body: '{}', headers: { 'Content-Type' => 'application/json' })
+
+      upload.post(path: 'base/', params: { 'UPLOADCARE_PUB_KEY' => 'demopublickey' })
+
+      expect(
+        a_request(:post, 'https://upload.uploadcare.com/base/')
+          .with(headers: { 'User-Agent' => %r{\AUploadcareRuby/} })
+      ).to have_been_made
+    end
+
+    it 'sends the SDK User-Agent when uploading parts to a presigned URL' do
+      presigned_url = 'https://s3.amazonaws.com/bucket/part?signature=abc123'
+      stub_request(:put, presigned_url)
+        .with(headers: { 'User-Agent' => expected_user_agent })
+        .to_return(status: 200, body: '', headers: {})
+
+      upload.upload_part_to_url(presigned_url, 'binary-data')
+
+      expect(
+        a_request(:put, presigned_url)
+          .with(headers: { 'User-Agent' => %r{\AUploadcareRuby/} })
+      ).to have_been_made
+    end
+  end
+
   describe '#upload_part_to_url' do
     let(:presigned_url) { 'https://s3.amazonaws.com/bucket/part?signature=abc123' }
 


### PR DESCRIPTION
REST API requests correctly report the SDK User-Agent (`UploadcareRuby/5.0.0/<pub_key> (Ruby/3.3.x)`), but **Upload API** requests are going out as `Faraday v2.14.2`. This regressed in the v5 architecture rewrite; v3.x cassettes still show the correct `UploadcareRuby/...` UA.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed User-Agent header handling to ensure all API requests, including upload and multipart upload operations, consistently use the SDK-generated User-Agent identifier.

* **Tests**
  * Added comprehensive tests verifying that REST and Upload API requests include the SDK-generated User-Agent header.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->